### PR TITLE
Update sample app version for 1.1.2 release

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         applicationId = "io.hammerhead.sampleext"
         minSdk = 23
         targetSdk = 34
-        versionCode = 5
-        versionName = "2.0"
+        versionCode = 6
+        versionName = "2.1"
     }
 
     buildTypes {

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -3,8 +3,8 @@
   "packageName": "io.hammerhead.sampleext",
   "iconUrl": "https://github.com/hammerheadnav/karoo-ext/releases/latest/download/karoo-ext-sample.png",
   "latestApkUrl": "https://github.com/hammerheadnav/karoo-ext/releases/latest/download/karoo-ext-sample.apk",
-  "latestVersion": "2.0",
-  "latestVersionCode": 5,
+  "latestVersion": "2.1",
+  "latestVersionCode": 6,
   "developer": "Hammerhead",
   "description": "Hammerhead's Sample app from github.com/hammerheadnav/karoo-ext which demonstrates the capabilities of Karoo Extensions.\nIt won't provide much use to riders but can be a quick way to get started developing for Karoo.",
   "releaseNotes": "Added manifest meta-data for release."


### PR DESCRIPTION
Bump versions for sample app to be included in release 1.1.2 so Karoo can show app update.