### PR TITLE
Add FIT file effects and capabilities

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         applicationId = "io.hammerhead.sampleext"
         minSdk = 23
         targetSdk = 34
-        versionCode = 6
-        versionName = "2.1"
+        versionCode = 7
+        versionName = "2.2"
     }
 
     buildTypes {

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -3,9 +3,9 @@
   "packageName": "io.hammerhead.sampleext",
   "iconUrl": "https://github.com/hammerheadnav/karoo-ext/releases/latest/download/karoo-ext-sample.png",
   "latestApkUrl": "https://github.com/hammerheadnav/karoo-ext/releases/latest/download/karoo-ext-sample.apk",
-  "latestVersion": "2.1",
-  "latestVersionCode": 6,
+  "latestVersion": "2.2",
+  "latestVersionCode": 7,
   "developer": "Hammerhead",
   "description": "Hammerhead's Sample app from github.com/hammerheadnav/karoo-ext which demonstrates the capabilities of Karoo Extensions.\nIt won't provide much use to riders but can be a quick way to get started developing for Karoo.",
-  "releaseNotes": "Added manifest meta-data for release."
+  "releaseNotes": "Added custom FIT file samples."
 }

--- a/app/src/main/kotlin/io/hammerhead/sampleext/extension/SampleExtension.kt
+++ b/app/src/main/kotlin/io/hammerhead/sampleext/extension/SampleExtension.kt
@@ -47,7 +47,6 @@ import io.hammerhead.karooext.models.StreamState
 import io.hammerhead.karooext.models.Symbol
 import io.hammerhead.karooext.models.SystemNotification
 import io.hammerhead.karooext.models.UserProfile
-import io.hammerhead.karooext.models.WriteFieldDescriptionMesg
 import io.hammerhead.karooext.models.WriteToRecordMesg
 import io.hammerhead.sampleext.R
 import kotlinx.coroutines.CoroutineScope
@@ -177,9 +176,6 @@ class SampleExtension : KarooExtension("sample", "1.0") {
 
     override fun startFit(emitter: Emitter<FitEffect>) {
         val job = CoroutineScope(Dispatchers.IO).launch {
-            // Always start by defining developer field before use
-            emitter.onNext(WriteFieldDescriptionMesg(developerField))
-
             repeat(Int.MAX_VALUE) { inc ->
                 Timber.d("BRENT: FIT $inc")
                 emitter.onNext(

--- a/app/src/main/res/xml/extension_info.xml
+++ b/app/src/main/res/xml/extension_info.xml
@@ -4,7 +4,8 @@
     icon="@drawable/ic_sample"
     id="sample"
     scansDevices="true"
-    mapLayer="true">
+    mapLayer="true"
+    fitFile="true">
     <DataType
         description="@string/custom_speed_description"
         displayName="@string/custom_speed"

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 val moduleName = "karoo-ext"
-val libVersion = "1.1.3"
+val libVersion = "1.1.4"
 
 buildscript {
     dependencies {

--- a/lib/src/main/aidl/io/hammerhead/karooext/aidl/IKarooExtension.aidl
+++ b/lib/src/main/aidl/io/hammerhead/karooext/aidl/IKarooExtension.aidl
@@ -19,4 +19,7 @@ interface IKarooExtension {
 
     oneway void startMap(String id, in IHandler handler);
     oneway void stopMap(String id);
+
+    oneway void startFit(String id, in IHandler handler);
+    oneway void stopFit(String id);
 }

--- a/lib/src/main/kotlin/io/hammerhead/karooext/extension/KarooExtension.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/extension/KarooExtension.kt
@@ -30,6 +30,7 @@ import io.hammerhead.karooext.models.DataType
 import io.hammerhead.karooext.models.Device
 import io.hammerhead.karooext.models.DeviceEvent
 import io.hammerhead.karooext.models.ExtensionInfo
+import io.hammerhead.karooext.models.FitEffect
 import io.hammerhead.karooext.models.MapEffect
 import io.hammerhead.karooext.models.StreamState
 import io.hammerhead.karooext.models.ViewConfig
@@ -137,6 +138,18 @@ abstract class KarooExtension(
                 Timber.d("$TAG: stopMap $id")
                 emitters.remove(id)?.cancel()
             }
+
+            override fun startFit(id: String, handler: IHandler) {
+                val emitter = Emitter.create<FitEffect>(packageName, handler)
+                emitters[id] = emitter
+                Timber.d("$TAG: startFit $id")
+                startFit(emitter)
+            }
+
+            override fun stopFit(id: String) {
+                Timber.d("$TAG: stopFit $id")
+                emitters.remove(id)?.cancel()
+            }
         }
     }
 
@@ -172,6 +185,15 @@ abstract class KarooExtension(
      * @since 1.1.3
      */
     open fun startMap(emitter: Emitter<MapEffect>) {}
+
+    /**
+     * Start providing effects for FIT file writing
+     *
+     * This will be called only if [ExtensionInfo] has `fitFile` set to true
+     *
+     * @see [FitEffect]
+     */
+    open fun startFit(emitter: Emitter<FitEffect>) {}
 
     /**
      * @suppress

--- a/lib/src/main/kotlin/io/hammerhead/karooext/extension/KarooExtension.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/extension/KarooExtension.kt
@@ -24,7 +24,6 @@ import io.hammerhead.karooext.EXT_LIB_VERSION
 import io.hammerhead.karooext.aidl.IHandler
 import io.hammerhead.karooext.aidl.IKarooExtension
 import io.hammerhead.karooext.internal.Emitter
-import io.hammerhead.karooext.internal.FitEmitter
 import io.hammerhead.karooext.internal.ViewEmitter
 import io.hammerhead.karooext.internal.serializableFromBundle
 import io.hammerhead.karooext.models.DataType
@@ -141,7 +140,7 @@ abstract class KarooExtension(
             }
 
             override fun startFit(id: String, handler: IHandler) {
-                val emitter = FitEmitter(packageName, handler)
+                val emitter = Emitter.create<FitEffect>(packageName, handler)
                 emitters[id] = emitter
                 Timber.d("$TAG: startFit $id")
                 startFit(emitter)

--- a/lib/src/main/kotlin/io/hammerhead/karooext/extension/KarooExtension.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/extension/KarooExtension.kt
@@ -24,6 +24,7 @@ import io.hammerhead.karooext.EXT_LIB_VERSION
 import io.hammerhead.karooext.aidl.IHandler
 import io.hammerhead.karooext.aidl.IKarooExtension
 import io.hammerhead.karooext.internal.Emitter
+import io.hammerhead.karooext.internal.FitEmitter
 import io.hammerhead.karooext.internal.ViewEmitter
 import io.hammerhead.karooext.internal.serializableFromBundle
 import io.hammerhead.karooext.models.DataType
@@ -140,7 +141,7 @@ abstract class KarooExtension(
             }
 
             override fun startFit(id: String, handler: IHandler) {
-                val emitter = Emitter.create<FitEffect>(packageName, handler)
+                val emitter = FitEmitter(packageName, handler)
                 emitters[id] = emitter
                 Timber.d("$TAG: startFit $id")
                 startFit(emitter)

--- a/lib/src/main/kotlin/io/hammerhead/karooext/internal/Emitter.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/internal/Emitter.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025 SRAM LLC.
+ * Copyright (c) 2024 SRAM LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/src/main/kotlin/io/hammerhead/karooext/internal/Emitter.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/internal/Emitter.kt
@@ -21,13 +21,7 @@ import android.widget.RemoteViews
 import io.hammerhead.karooext.BUNDLE_PACKAGE
 import io.hammerhead.karooext.BUNDLE_VALUE
 import io.hammerhead.karooext.aidl.IHandler
-import io.hammerhead.karooext.models.DeveloperField
-import io.hammerhead.karooext.models.FieldValue
-import io.hammerhead.karooext.models.FitEffect
 import io.hammerhead.karooext.models.ViewEvent
-import io.hammerhead.karooext.models.WriteEventMesg
-import io.hammerhead.karooext.models.WriteFieldDescriptionMesg
-import io.hammerhead.karooext.models.WriteToRecordMesg
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -126,31 +120,5 @@ class ViewEmitter(
         bundle.putParcelable("view", view)
         bundle.putString(BUNDLE_PACKAGE, packageName)
         handler.onNext(bundle)
-    }
-}
-
-/**
- * Special [Emitter] that validates writing of developer fields with [FitEffect].
- */
-class FitEmitter(
-    private val packageName: String,
-    private val handler: IHandler,
-    private val effectEmitter: Emitter<FitEffect> = Emitter.create<FitEffect>(packageName, handler),
-) : Emitter<FitEffect> by effectEmitter {
-    private val developerFields = mutableSetOf<DeveloperField>()
-
-    override fun onNext(t: FitEffect) {
-        when (t) {
-            is WriteEventMesg -> checkDeveloperFields(t.values)
-            is WriteToRecordMesg -> checkDeveloperFields(t.values)
-            is WriteFieldDescriptionMesg -> developerFields.add(t.developerField)
-        }
-        effectEmitter.onNext(t)
-    }
-
-    private fun checkDeveloperFields(values: List<FieldValue>) {
-        if (values.any { it.developerField != null && !developerFields.contains(it.developerField) }) {
-            throw IllegalStateException("Undeclared developer field in ${values}, see WriteFieldDescriptionMesg")
-        }
     }
 }

--- a/lib/src/main/kotlin/io/hammerhead/karooext/internal/Emitter.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/internal/Emitter.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 SRAM LLC.
+ * Copyright (c) 2025 SRAM LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,13 @@ import android.widget.RemoteViews
 import io.hammerhead.karooext.BUNDLE_PACKAGE
 import io.hammerhead.karooext.BUNDLE_VALUE
 import io.hammerhead.karooext.aidl.IHandler
+import io.hammerhead.karooext.models.DeveloperField
+import io.hammerhead.karooext.models.FieldValue
+import io.hammerhead.karooext.models.FitEffect
 import io.hammerhead.karooext.models.ViewEvent
+import io.hammerhead.karooext.models.WriteEventMesg
+import io.hammerhead.karooext.models.WriteFieldDescriptionMesg
+import io.hammerhead.karooext.models.WriteToRecordMesg
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -120,5 +126,31 @@ class ViewEmitter(
         bundle.putParcelable("view", view)
         bundle.putString(BUNDLE_PACKAGE, packageName)
         handler.onNext(bundle)
+    }
+}
+
+/**
+ * Special [Emitter] that validates writing of developer fields with [FitEffect].
+ */
+class FitEmitter(
+    private val packageName: String,
+    private val handler: IHandler,
+    private val effectEmitter: Emitter<FitEffect> = Emitter.create<FitEffect>(packageName, handler),
+) : Emitter<FitEffect> by effectEmitter {
+    private val developerFields = mutableSetOf<DeveloperField>()
+
+    override fun onNext(t: FitEffect) {
+        when (t) {
+            is WriteEventMesg -> checkDeveloperFields(t.values)
+            is WriteToRecordMesg -> checkDeveloperFields(t.values)
+            is WriteFieldDescriptionMesg -> developerFields.add(t.developerField)
+        }
+        effectEmitter.onNext(t)
+    }
+
+    private fun checkDeveloperFields(values: List<FieldValue>) {
+        if (values.any { it.developerField != null && !developerFields.contains(it.developerField) }) {
+            throw IllegalStateException("Undeclared developer field in ${values}, see WriteFieldDescriptionMesg")
+        }
     }
 }

--- a/lib/src/main/kotlin/io/hammerhead/karooext/models/ExtensionInfo.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/models/ExtensionInfo.kt
@@ -55,6 +55,12 @@ data class ExtensionInfo(
      */
     val mapLayer: Boolean,
     /**
+     * Whether this extension writes to the FIT file.
+     *
+     * @see [KarooExtension.startFit]
+     */
+    val fitFile: Boolean,
+    /**
      * Static list of [DataType]s this extension provides.
      *
      * @see [DataType]

--- a/lib/src/main/kotlin/io/hammerhead/karooext/models/FitEffect.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/models/FitEffect.kt
@@ -20,46 +20,108 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
 /**
+ * Effects that allow extensions to augment the recorded FIT file for each
+ * ride with additional data
+ *
+ * See [FIT SDK](https://developer.garmin.com/fit/overview/)
+ *
  * @since 1.1.4
  */
 @Serializable
 sealed interface FitEffect
 
+/**
+ * Encapsulation of [FitEffect] that have values
+ */
 @Serializable
 sealed interface FitEffectWithValues : FitEffect {
+    /**
+     * @suppress
+     */
     val values: List<FieldValue>
 
+    /**
+     * @suppress
+     */
     @Transient
     val developerFields: Set<DeveloperField>
         get() = values.mapNotNull { it.developerField }.toSet()
 
+    /**
+     * @suppress
+     */
     fun copyWith(values: List<FieldValue>): FitEffectWithValues
 }
 
 /**
+ * Developer Data Fields can be added to any message at runtime through the use of self-describing field definitions.
+ * These field definitions are included in the message definitions of the messages that they are used with,
+ * allowing for the custom fields to be decoded without the need for any prior knowledge of the Developer Data Fields.
+ *
+ * [Working With Developer Data Fields](https://developer.garmin.com/fit/cookbook/developer-data/)
+ *
  * @since 1.1.4
  */
 @Serializable
 data class DeveloperField(
+    /**
+     * Unique field number
+     *
+     * For a given extension, each associated Field Description should have a sequential Field Definition number.
+     * This value is also an index and should start at 0 and increase sequentially by 1.
+     * A FIT file can contain up to 255 unique Field Descriptions per extension.
+     *
+     * The definition of a developer field will be written to the FIT file when first used in any [FitEffectWithValues].
+     */
     val fieldDefinitionNumber: Short,
+    /**
+     * Base type of this data
+     *
+     * See the Garmin FIT SDK for constants.
+     */
     val fitBaseTypeId: Short,
+    /**
+     * Field name for this developer field
+     */
     val fieldName: String,
+    /**
+     * Units associated with the developer field
+     */
     val units: String,
+    /**
+     * The Native Field Number provides a way to convey which native field the data should be considered as.
+     *
+     * The Native Field Number is a more deterministic way of conveying this information when compared to the field name and unit properties,
+     * which are defined using strings and may vary subtly from vendor to vendor making comparisons difficult.
+     */
     val nativeFieldNum: Short? = null,
     /**
-     * Do not use. Populated by Karoo System.
+     * Populated by Karoo System and ignored if set by extensions
      */
     val developerDataIndex: Short = 0,
 )
 
 /**
+ * Field and value pair
+ *
  * @since 1.1.4
  */
 @Suppress("unused", "DataClassPrivateConstructor")
 @Serializable
 data class FieldValue private constructor(
+    /**
+     * Standard field number
+     */
     val fieldNum: Int,
+    /**
+     * Value of this data
+     *
+     * Final FIT file will be casted/rounded based on FIT defined type.
+     */
     val value: Double,
+    /**
+     * Associated developer field if non-standard
+     */
     val developerField: DeveloperField?,
 ) {
     /**
@@ -74,42 +136,78 @@ data class FieldValue private constructor(
 }
 
 /**
+ * Write a new EventMesg to the FIT file
+ *
  * @since 1.1.4
  */
 @Serializable
 data class WriteEventMesg(
+    /**
+     * Ordinal of com.garmin.fit.Event from FIT SDK
+     */
     val event: Short,
+    /**
+     * Ordinal of com.garmin.fit.EventType from FIT SDK
+     */
     val eventType: Short,
+    /**
+     * Values associated with this event
+     */
     override val values: List<FieldValue>,
 ) : FitEffectWithValues {
+    /**
+     * @suppress
+     */
     override fun copyWith(values: List<FieldValue>): FitEffectWithValues {
         return copy(values = values)
     }
 }
 
 /**
+ * Write values to the RecordMesg which are written to the FIT file at 1Hz
+ *
  * @since 1.1.4
  */
 @Serializable
 data class WriteToRecordMesg(
+    /**
+     * Values to add to the RecordMesg
+     */
     override val values: List<FieldValue>,
 ) : FitEffectWithValues {
+    /**
+     * Convenience constructor for a single field/value
+     */
     constructor(value: FieldValue) : this(listOf(value))
 
+    /**
+     * @suppress
+     */
     override fun copyWith(values: List<FieldValue>): FitEffectWithValues {
         return copy(values = values)
     }
 }
 
 /**
+ * Write values to the final SessionMesg for the ride
+ *
  * @since 1.1.4
  */
 @Serializable
 data class WriteToSessionMesg(
+    /**
+     * Values to add to the SessionMesg
+     */
     override val values: List<FieldValue>,
 ) : FitEffectWithValues {
+    /**
+     * Convenience constructor for a single field/value
+     */
     constructor(value: FieldValue) : this(listOf(value))
 
+    /**
+     * @suppress
+     */
     override fun copyWith(values: List<FieldValue>): FitEffectWithValues {
         return copy(values = values)
     }

--- a/lib/src/main/kotlin/io/hammerhead/karooext/models/FitEffect.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/models/FitEffect.kt
@@ -214,13 +214,18 @@ data class WriteToSessionMesg(
 }
 
 /**
- * @suppress
+ * Internal use by Karoo System when the first [DeveloperField] is used in [FitEffectWithValues]
+ *
+ * Ignored if emitted by an extension
  */
 @Serializable
 data class WriteDeveloperDataIdMesg(val developerDataId: Short) : FitEffect
 
+
 /**
- * @suppress
+ * Internal use by Karoo System when a new [DeveloperField] is used in [FitEffectWithValues]
+ *
+ * Ignored if emitted by an extension
  */
 @Serializable
 data class WriteFieldDescriptionMesg(val developerField: DeveloperField) : FitEffect

--- a/lib/src/main/kotlin/io/hammerhead/karooext/models/FitEffect.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/models/FitEffect.kt
@@ -34,6 +34,7 @@ data class DeveloperField(
     val fitBaseTypeId: Short,
     val fieldName: String,
     val units: String,
+    val nativeFieldNum: Short? = null,
     /**
      * Do not use. Populated by Karoo System.
      */
@@ -43,13 +44,21 @@ data class DeveloperField(
 /**
  * @since 1.1.4
  */
-@Suppress("unused")
+@Suppress("unused", "DataClassPrivateConstructor")
 @Serializable
-data class FieldValue(
+data class FieldValue private constructor(
     val fieldNum: Short,
     val value: Double,
-    val developerField: DeveloperField? = null,
+    val developerField: DeveloperField?,
 ) {
+    /**
+     * Create field value with standard field definition
+     */
+    constructor(fieldNum: Short, value: Double) : this(fieldNum, value, null)
+
+    /**
+     * Create field value for a custom-defined developer field
+     */
     constructor(developerField: DeveloperField, value: Double) : this(developerField.fieldDefinitionNumber, value, developerField)
 }
 

--- a/lib/src/main/kotlin/io/hammerhead/karooext/models/FitEffect.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/models/FitEffect.kt
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2025 SRAM LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.hammerhead.karooext.models
+
+import kotlinx.serialization.Serializable
+
+/**
+ * @since 1.1.4
+ */
+@Serializable
+sealed class FitEffect
+
+
+/**
+ * @since 1.1.4
+ */
+@Serializable
+data class DeveloperField(
+    val fieldDefinitionNumber: Short,
+    val fitBaseTypeId: Short,
+    val fieldName: String,
+    val units: String,
+    /**
+     * Do not use. Populated by Karoo System.
+     */
+    val developerDataIndex: Short = 0,
+)
+
+/**
+ * @since 1.1.4
+ */
+@Suppress("unused")
+@Serializable
+data class FieldValue(
+    val fieldNum: Short,
+    val value: Double,
+    val developerField: DeveloperField? = null,
+) {
+    constructor(developerField: DeveloperField, value: Double) : this(developerField.fieldDefinitionNumber, value, developerField)
+}
+
+/**
+ * @since 1.1.4
+ */
+@Serializable
+data class WriteFieldDescriptionMesg(
+    val developerField: DeveloperField,
+) : FitEffect()
+
+/**
+ * @since 1.1.4
+ */
+@Serializable
+data class WriteEventMesg(
+    val event: Short,
+    val eventType: Short,
+    val values: List<FieldValue>,
+) : FitEffect()
+
+/**
+ * @since 1.1.4
+ */
+@Serializable
+data class WriteToRecordMesg(val values: List<FieldValue>) : FitEffect() {
+    constructor(value: FieldValue) : this(listOf(value))
+}

--- a/lib/src/main/kotlin/io/hammerhead/karooext/models/FitEffect.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/models/FitEffect.kt
@@ -106,9 +106,9 @@ data class DeveloperField(
  *
  * @since 1.1.4
  */
-@Suppress("unused", "DataClassPrivateConstructor")
+@Suppress("unused")
 @Serializable
-data class FieldValue private constructor(
+data class FieldValue(
     /**
      * Standard field number
      */


### PR DESCRIPTION
Library:
* Add `FitEffect` as sealed class with options to:
  * Write to record mesg
  * Write to session mesg
  * Write an event
* Define developer data fields
* Add `fitFile` to extension info for XML and (optional) associated `startFit` call on Extension class
* Fixes #13

Sample:
* Write doughnuts to FIT file as custom developer field
* Write fake power to FIT file records
