### PR TITLE
Add ride profiles, saved devices, and bikes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         applicationId = "io.hammerhead.sampleext"
         minSdk = 23
         targetSdk = 34
-        versionCode = 7
-        versionName = "2.2"
+        versionCode = 8
+        versionName = "2.3"
     }
 
     buildTypes {

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -3,9 +3,9 @@
   "packageName": "io.hammerhead.sampleext",
   "iconUrl": "https://github.com/hammerheadnav/karoo-ext/releases/latest/download/karoo-ext-sample.png",
   "latestApkUrl": "https://github.com/hammerheadnav/karoo-ext/releases/latest/download/karoo-ext-sample.apk",
-  "latestVersion": "2.2",
-  "latestVersionCode": 7,
+  "latestVersion": "2.3",
+  "latestVersionCode": 8,
   "developer": "Hammerhead",
   "description": "Hammerhead's Sample app from github.com/hammerheadnav/karoo-ext which demonstrates the capabilities of Karoo Extensions.\nIt won't provide much use to riders but can be a quick way to get started developing for Karoo.",
-  "releaseNotes": "Added custom FIT file samples."
+  "releaseNotes": "Added additional events."
 }

--- a/app/src/main/kotlin/io/hammerhead/sampleext/MainViewModel.kt
+++ b/app/src/main/kotlin/io/hammerhead/sampleext/MainViewModel.kt
@@ -22,7 +22,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.hammerhead.karooext.KarooSystemService
+import io.hammerhead.karooext.models.ActiveRidePage
+import io.hammerhead.karooext.models.ActiveRideProfile
 import io.hammerhead.karooext.models.ApplyLauncherBackground
+import io.hammerhead.karooext.models.Bikes
 import io.hammerhead.karooext.models.DataType
 import io.hammerhead.karooext.models.HardwareType
 import io.hammerhead.karooext.models.HttpResponseState
@@ -34,7 +37,9 @@ import io.hammerhead.karooext.models.OnMapZoomLevel
 import io.hammerhead.karooext.models.OnNavigationState
 import io.hammerhead.karooext.models.OnStreamState
 import io.hammerhead.karooext.models.PlayBeepPattern
+import io.hammerhead.karooext.models.RideProfile
 import io.hammerhead.karooext.models.RideState
+import io.hammerhead.karooext.models.SavedDevices
 import io.hammerhead.karooext.models.StreamState
 import io.hammerhead.karooext.models.Symbol
 import io.hammerhead.karooext.models.UserProfile
@@ -66,6 +71,10 @@ data class MainData(
     val httpStatus: String? = null,
     val navigationState: OnNavigationState.NavigationState? = null,
     val globalPOIs: List<Symbol.POI> = emptyList(),
+    val savedDevices: List<SavedDevices.SavedDevice> = emptyList(),
+    val bikes: List<Bikes.Bike> = emptyList(),
+    val rideProfile: RideProfile? = null,
+    val activePage: RideProfile.Page? = null,
 )
 
 val json = Json {
@@ -159,6 +168,18 @@ class MainViewModel @Inject constructor(
                 }
                 karooSystem.addConsumer { event: OnGlobalPOIs ->
                     mutableState.update { it.copy(globalPOIs = event.pois) }
+                }
+                karooSystem.addConsumer { event: SavedDevices ->
+                    mutableState.update { it.copy(savedDevices = event.devices) }
+                }
+                karooSystem.addConsumer { event: Bikes ->
+                    mutableState.update { it.copy(bikes = event.bikes) }
+                }
+                karooSystem.addConsumer { event: ActiveRideProfile ->
+                    mutableState.update { it.copy(rideProfile = event.profile) }
+                }
+                karooSystem.addConsumer { event: ActiveRidePage ->
+                    mutableState.update { it.copy(activePage = event.page) }
                 }
                 karooSystem.addConsumer { zoom: OnMapZoomLevel ->
                     Timber.i("Map zoom $zoom")

--- a/app/src/main/kotlin/io/hammerhead/sampleext/TabLayout.kt
+++ b/app/src/main/kotlin/io/hammerhead/sampleext/TabLayout.kt
@@ -64,7 +64,7 @@ fun TabLayout(
     playBeeps: () -> Unit,
     toggleHomeBackground: () -> Unit,
 ) {
-    var selectedTabIndex by remember { mutableIntStateOf(0) }
+    var selectedTabIndex by remember { mutableIntStateOf(1) }
     val tabs = listOf("Controls", "Data", "Requests")
 
     Column(modifier = Modifier.fillMaxSize()) {
@@ -156,8 +156,6 @@ fun ControlsTab(
 
 @Composable
 fun DataTab(mainData: MainData) {
-    var isPOIDialogOpen by remember { mutableStateOf(false) }
-
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -167,35 +165,64 @@ fun DataTab(mainData: MainData) {
         Text(text = "Ride State: ${mainData.rideState}")
         Text(text = "Power: ${(mainData.power as? StreamState.Streaming)?.dataPoint?.singleValue ?: "--"}")
         Text(text = "Navigation: ${mainData.navigationState}")
-        Button(
-            onClick = { isPOIDialogOpen = true },
-            colors = ButtonDefaults.textButtonColors(containerColor = Color.Magenta, contentColor = Color.White),
+        Text(text = "Active profile: ${mainData.rideProfile}")
+        Text(text = "Active page: ${mainData.activePage}")
+        ExpandableData(
+            buttonText = "Global POIs",
+            buttonColor = Color.Magenta,
             modifier = Modifier.align(Alignment.CenterHorizontally),
         ) {
-            Text("Global POIs")
+            mainData.globalPOIs.map {
+                Text("POI: ${it.name ?: ""} ${it.type}")
+            }
         }
-        if (isPOIDialogOpen) {
-            AlertDialog(
-                onDismissRequest = { isPOIDialogOpen = false },
-                text = {
-                    Column(
-                        modifier = Modifier
-                            .verticalScroll(rememberScrollState())
-                            .padding(4.dp),
-                    ) {
-                        mainData.globalPOIs.map {
-                            Text("POI: ${it.name ?: ""} ${it.type}")
-                        }
-                    }
-                },
-                confirmButton = {
-                    Button(onClick = { isPOIDialogOpen = false }) {
-                        Text("Close")
-                    }
-                },
-                modifier = Modifier.padding(10.dp),
-            )
+        ExpandableData(
+            buttonText = "Saved Devices",
+            buttonColor = Color.DarkGray,
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+        ) {
+            mainData.savedDevices.map {
+                Text("Device: $it")
+            }
         }
+    }
+}
+
+@Composable
+fun ExpandableData(
+    buttonText: String,
+    buttonColor: Color,
+    modifier: Modifier,
+    content: @Composable () -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Button(
+        onClick = { expanded = true },
+        colors = ButtonDefaults.textButtonColors(containerColor = buttonColor, contentColor = Color.White),
+        modifier = modifier,
+    ) {
+        Text(buttonText)
+    }
+    if (expanded) {
+        AlertDialog(
+            onDismissRequest = { expanded = false },
+            text = {
+                Column(
+                    modifier = Modifier
+                        .verticalScroll(rememberScrollState())
+                        .padding(4.dp),
+                ) {
+                    content()
+                }
+            },
+            confirmButton = {
+                Button(onClick = { expanded = false }) {
+                    Text("Close")
+                }
+            },
+            modifier = Modifier.padding(10.dp),
+        )
     }
 }
 

--- a/app/src/main/kotlin/io/hammerhead/sampleext/TabLayout.kt
+++ b/app/src/main/kotlin/io/hammerhead/sampleext/TabLayout.kt
@@ -46,6 +46,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.util.fastRoundToInt
+import io.hammerhead.karooext.models.Device
 import io.hammerhead.karooext.models.KarooEffect
 import io.hammerhead.karooext.models.LaunchPinDrop
 import io.hammerhead.karooext.models.PerformHardwareAction
@@ -64,7 +66,7 @@ fun TabLayout(
     playBeeps: () -> Unit,
     toggleHomeBackground: () -> Unit,
 ) {
-    var selectedTabIndex by remember { mutableIntStateOf(1) }
+    var selectedTabIndex by remember { mutableIntStateOf(0) }
     val tabs = listOf("Controls", "Data", "Requests")
 
     Column(modifier = Modifier.fillMaxSize()) {
@@ -166,7 +168,22 @@ fun DataTab(mainData: MainData) {
         Text(text = "Power: ${(mainData.power as? StreamState.Streaming)?.dataPoint?.singleValue ?: "--"}")
         Text(text = "Navigation: ${mainData.navigationState}")
         Text(text = "Active profile: ${mainData.rideProfile}")
-        Text(text = "Active page: ${mainData.activePage}")
+        ExpandableData(
+            buttonText = "Bikes",
+            buttonColor = Color.Green,
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+        ) {
+            mainData.bikes.map {
+                Text("${it.name}: ${it.odometer.fastRoundToInt()}m")
+            }
+        }
+        ExpandableData(
+            buttonText = "Active page",
+            buttonColor = Color.Blue,
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+        ) {
+            Text(mainData.activePage.toString())
+        }
         ExpandableData(
             buttonText = "Global POIs",
             buttonColor = Color.Magenta,
@@ -182,7 +199,8 @@ fun DataTab(mainData: MainData) {
             modifier = Modifier.align(Alignment.CenterHorizontally),
         ) {
             mainData.savedDevices.map {
-                Text("Device: $it")
+                val extDetails = Device.fromDeviceUid(it.id)?.let { "[ext=${it.first} id=${it.second}]" } ?: ""
+                Text("Device: ${it.name} (${it.connectionType}) $extDetails")
             }
         }
     }

--- a/app/src/main/kotlin/io/hammerhead/sampleext/extension/SampleExtension.kt
+++ b/app/src/main/kotlin/io/hammerhead/sampleext/extension/SampleExtension.kt
@@ -223,7 +223,7 @@ class SampleExtension : KarooExtension("sample", "1.0") {
                                 event = 7, // OFF_COURSE((short)7),
                                 eventType = 3, // MARKER((short)3),
                                 values = listOf(doughnutsField),
-                            )
+                            ),
                         )
                     }
                 }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 val moduleName = "karoo-ext"
-val libVersion = "1.1.4"
+val libVersion = "1.1.5"
 
 buildscript {
     dependencies {

--- a/lib/src/main/kotlin/io/hammerhead/karooext/KarooSystemService.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/KarooSystemService.kt
@@ -27,6 +27,9 @@ import io.hammerhead.karooext.internal.KarooSystemListener
 import io.hammerhead.karooext.internal.bundleWithSerializable
 import io.hammerhead.karooext.internal.createConsumer
 import io.hammerhead.karooext.internal.serializableFromBundle
+import io.hammerhead.karooext.models.ActiveRidePage
+import io.hammerhead.karooext.models.ActiveRideProfile
+import io.hammerhead.karooext.models.Bikes
 import io.hammerhead.karooext.models.HardwareType
 import io.hammerhead.karooext.models.KarooEffect
 import io.hammerhead.karooext.models.KarooEvent
@@ -38,6 +41,7 @@ import io.hammerhead.karooext.models.OnLocationChanged
 import io.hammerhead.karooext.models.OnMapZoomLevel
 import io.hammerhead.karooext.models.OnNavigationState
 import io.hammerhead.karooext.models.RideState
+import io.hammerhead.karooext.models.SavedDevices
 import io.hammerhead.karooext.models.UserProfile
 import timber.log.Timber
 import java.util.UUID
@@ -234,6 +238,10 @@ class KarooSystemService(private val context: Context) {
             OnGlobalPOIs::class -> OnGlobalPOIs.Params
             OnNavigationState::class -> OnNavigationState.Params
             OnMapZoomLevel::class -> OnMapZoomLevel.Params
+            SavedDevices::class -> SavedDevices.Params
+            Bikes::class -> Bikes.Params
+            ActiveRideProfile::class -> ActiveRideProfile.Params
+            ActiveRidePage::class -> ActiveRidePage.Params
             else -> throw IllegalArgumentException("No default KarooEventParams for ${T::class}")
         }
         return addConsumer<T>(params, onError, onComplete, onEvent)

--- a/lib/src/main/kotlin/io/hammerhead/karooext/models/DataType.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/models/DataType.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 SRAM LLC.
+ * Copyright (c) 2025 SRAM LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,36 +87,42 @@ data class DataType(
         /**
          * Speed - Current speed
          * Fields: [Field.SPEED]
+         * Units: km/h (metric), mph (imperial)
          */
         const val SPEED = "TYPE_SPEED_ID"
 
         /**
          * Average Speed - Avg. speed this ride
          * Fields: [Field.AVERAGE_SPEED]
+         * Units: km/h (metric), mph (imperial)
          */
         const val AVERAGE_SPEED = "TYPE_AVERAGE_SPEED_ID"
 
         /**
          * Max Speed - Max. speed this ride
          * Fields: [Field.MAX_SPEED]
+         * Units: km/h (metric), mph (imperial)
          */
         const val MAX_SPEED = "TYPE_MAX_SPEED_ID"
 
         /**
          * 3s Average Speed - 3-second rolling avg.
          * Fields: [Field.SMOOTHED_3S_AVERAGE_SPEED]
+         * Units: km/h (metric), mph (imperial)
          */
         const val SMOOTHED_3S_AVERAGE_SPEED = "TYPE_3S_AVERAGE_SPEED_ID"
 
         /**
          * 5s Average Speed - 5-second rolling avg.
          * Fields: [Field.SMOOTHED_5S_AVERAGE_SPEED]
+         * Units: km/h (metric), mph (imperial)
          */
         const val SMOOTHED_5S_AVERAGE_SPEED = "TYPE_5S_AVERAGE_SPEED_ID"
 
         /**
          * 10s Average Speed - 10-second rolling avg.
          * Fields: [Field.SMOOTHED_10S_AVERAGE_SPEED]
+         * Units: km/h (metric), mph (imperial)
          */
         const val SMOOTHED_10S_AVERAGE_SPEED = "TYPE_10S_AVERAGE_SPEED_ID"
 
@@ -127,6 +133,7 @@ data class DataType(
         /**
          * Distance - Distance traveled this ride
          * Fields: [Field.DISTANCE]
+         * Units: km (metric), mi (imperial)
          */
         const val DISTANCE = "TYPE_DISTANCE_ID"
 
@@ -137,6 +144,7 @@ data class DataType(
         /**
          * Heart Rate - Current HR
          * Fields: [Field.HEART_RATE]
+         * Units: bpm
          */
         const val HEART_RATE = "TYPE_HEART_RATE_ID"
 
@@ -149,18 +157,21 @@ data class DataType(
         /**
          * Average Heart Rate - Avg. HR this ride
          * Fields: [Field.AVG_HR]
+         * Units: bpm
          */
         const val AVERAGE_HR = "TYPE_AVERAGE_HR_ID"
 
         /**
          * Max Heart Rate - Max. HR this ride
          * Fields: [Field.MAX_HR]
+         * Units: bpm
          */
         const val MAX_HR = "TYPE_MAX_HR_ID"
 
         /**
          * Percentage of Max HR - Ratio of current HR to your max.
          * Fields: [Field.PERCENT_MAX_HR]
+         * Units: %
          */
         const val PERCENT_MAX_HR = "TYPE_PERCENT_MAX_HR_ID"
 
@@ -173,6 +184,7 @@ data class DataType(
         /**
          * Average % of HRR - Avg. ratio of HR to your HR Reserve this ride
          * Fields: [Field.AVERAGE_PERCENT_HRR]
+         * Units: bpm
          */
         const val AVERAGE_PERCENT_HRR = "TYPE_AVERAGE_PERCENT_HRR_ID"
 
@@ -183,36 +195,42 @@ data class DataType(
         /**
          * Cadence - Current pedaling rate
          * Fields: [Field.CADENCE]
+         * Units: rpm
          */
         const val CADENCE = "TYPE_CADENCE_ID"
 
         /**
          * Average Cadence - Avg. pedaling rate this ride
          * Fields: [Field.AVERAGE_CADENCE]
+         * Units: rpm
          */
         const val AVERAGE_CADENCE = "TYPE_AVERAGE_CADENCE_ID"
 
         /**
          * Max Cadence - Max. pedaling rate this ride
          * Fields: [Field.MAX_CADENCE]
+         * Units: rpm
          */
         const val MAX_CADENCE = "TYPE_MAX_CADENCE_ID"
 
         /**
          * 3s Average Cadence - 3-second rolling avg.
          * Fields: [Field.SMOOTHED_3S_AVERAGE_CADENCE]
+         * Units: rpm
          */
         const val SMOOTHED_3S_AVERAGE_CADENCE = "TYPE_3S_AVERAGE_CADENCE_ID"
 
         /**
          * 5s Average Cadence - 5-second rolling avg.
          * Fields: [Field.SMOOTHED_5S_AVERAGE_CADENCE]
+         * Units: rpm
          */
         const val SMOOTHED_5S_AVERAGE_CADENCE = "TYPE_5S_AVERAGE_CADENCE_ID"
 
         /**
          * 10s Average Cadence - 10-second rolling avg.
          * Fields: [Field.SMOOTHED_10S_AVERAGE_CADENCE]
+         * Units: rpm
          */
         const val SMOOTHED_10S_AVERAGE_CADENCE = "TYPE_10S_AVERAGE_CADENCE_ID"
 
@@ -223,6 +241,7 @@ data class DataType(
         /**
          * Power - Current power output
          * Fields: [Field.POWER]
+         * Units: W
          */
         const val POWER = "TYPE_POWER_ID"
 
@@ -235,48 +254,56 @@ data class DataType(
         /**
          * Average Power - Avg. power output this ride
          * Fields: [Field.AVERAGE_POWER]
+         * Units: W
          */
         const val AVERAGE_POWER = "TYPE_AVERAGE_POWER_ID"
 
         /**
          * Max Power - Max. power output this ride
          * Fields: [Field.MAX_POWER]
+         * Units: W
          */
         const val MAX_POWER = "TYPE_MAX_POWER_ID"
 
         /**
          * 3s Average Power - 3-second rolling avg.
          * Fields: [Field.SMOOTHED_3S_AVERAGE_POWER]
+         * Units: W
          */
         const val SMOOTHED_3S_AVERAGE_POWER = "TYPE_3S_AVERAGE_POWER_ID"
 
         /**
          * 5s Average Power - 5-second rolling avg.
          * Fields: [Field.SMOOTHED_5S_AVERAGE_POWER]
+         * Units: W
          */
         const val SMOOTHED_5S_AVERAGE_POWER = "TYPE_5S_AVERAGE_POWER_ID"
 
         /**
          * 10s Average Power - 10-second rolling avg.
          * Fields: [Field.SMOOTHED_10S_AVERAGE_POWER]
+         * Units: W
          */
         const val SMOOTHED_10S_AVERAGE_POWER = "TYPE_10S_AVERAGE_POWER_ID"
 
         /**
          * 30s Average Power - 30-second rolling avg.
          * Fields: [Field.SMOOTHED_30S_AVERAGE_POWER]
+         * Units: W
          */
         const val SMOOTHED_30S_AVERAGE_POWER = "TYPE_30S_AVERAGE_POWER_ID"
 
         /**
          * Normalized Power® - Normalized Power® this ride
          * Fields: [Field.NORMALIZED_POWER]
+         * Units: W
          */
         const val NORMALIZED_POWER = "TYPE_NORMALIZED_POWER_ID"
 
         /**
          * Percentage of FTP - Current power as a % of functional threshold power
          * Fields: [Field.PERCENT_MAX_FTP]
+         * Units: %
          */
         const val PERCENT_MAX_FTP = "TYPE_PERCENT_MAX_FTP_ID"
 
@@ -295,12 +322,14 @@ data class DataType(
         /**
          * 20min Average Power - 20-min. rolling avg.
          * Fields: [Field.SMOOTHED_20M_AVERAGE_POWER]
+         * Units: W
          */
         const val SMOOTHED_20M_AVERAGE_POWER = "TYPE_20M_AVERAGE_POWER_ID"
 
         /**
          * 1hr Average Power - 1-hr. rolling avg.
          * Fields: [Field.SMOOTHED_1HR_AVERAGE_POWER]
+         * Units: W
          */
         const val SMOOTHED_1HR_AVERAGE_POWER = "TYPE_1HR_AVERAGE_POWER_ID"
 
@@ -355,12 +384,14 @@ data class DataType(
         /**
          * Power to Weight - Power output in watts per kilogram
          * Fields: [Field.POWER_TO_WEIGHT]
+         * Units: W/Kg
          */
         const val POWER_TO_WEIGHT = "TYPE_POWER_TO_WEIGHT"
 
         /**
          * Energy Output - Amount of energy used this ride
          * Fields: [Field.ENERGY_OUTPUT]
+         * Units: kJ
          */
         const val ENERGY_OUTPUT = "TYPE_ENERGY_OUTPUT_ID"
 
@@ -373,6 +404,7 @@ data class DataType(
         /**
          * Calorie Burn Rate - Calories burned per hour this ride
          * Fields: [Field.CALORIES_PER_HOUR]
+         * Units: Cal/h
          */
         const val CALORIES_PER_HOUR = "TYPE_CALORIES_PER_HOUR_ID"
 
@@ -385,24 +417,28 @@ data class DataType(
         /**
          * Torque - Current torque in N⋅m
          * Fields: [Field.TORQUE]
+         * Units: N⋅m
          */
         const val TORQUE = "TYPE_TORQUE_ID"
 
         /**
          * 3s Average Torque - 3-second rolling avg. in N⋅m
          * Fields: [Field.TORQUE]
+         * Units: N⋅m
          */
         const val SMOOTHED_3S_AVERAGE_TORQUE = "TYPE_3S_AVERAGE_TORQUE_ID"
 
         /**
          * Average Torque - Average torque this ride in N⋅m
          * Fields: [Field.TORQUE]
+         * Units: N⋅m
          */
         const val AVERAGE_TORQUE = "TYPE_AVERAGE_TORQUE_ID"
 
         /**
          * Max Torque - Max. torque this ride in N⋅m
          * Fields: [Field.TORQUE]
+         * Units: N⋅m
          */
         const val MAX_TORQUE = "TYPE_MAX_TORQUE_ID"
 
@@ -425,54 +461,63 @@ data class DataType(
         /**
          * Lap Distance - Distance traveled this lap
          * Fields: [Field.DISTANCE]
+         * Units: km (metric), mi (imperial)
          */
         const val DISTANCE_LAP = "TYPE_DISTANCE_LAP_ID"
 
         /**
          * Lap Speed - Avg. speed this lap
          * Fields: [Field.AVERAGE_SPEED]
+         * Units: km/h (metric), mph (imperial)
          */
         const val AVERAGE_SPEED_LAP = "TYPE_AVERAGE_SPEED_LAP_ID"
 
         /**
          * Lap Max Speed - Max. speed this lap
          * Fields: [Field.MAX_SPEED]
+         * Units: km/h (metric), mph (imperial)
          */
         const val MAX_SPEED_LAP = "TYPE_MAX_SPEED_LAP_ID"
 
         /**
          * Lap Heart Rate - Avg. heart rate this lap
          * Fields: [Field.AVG_HR]
+         * Units: bpm
          */
         const val AVERAGE_LAP_HR = "TYPE_AVERAGE_LAP_HR_ID"
 
         /**
          * Lap Max Heart Rate - Max. heart rate this lap
          * Fields: [Field.MAX_HR]
+         * Units: bpm
          */
         const val MAX_HR_LAP = "TYPE_MAX_HR_LAP_ID"
 
         /**
          * Lap Cadence - Avg. cadence this lap
          * Fields: [Field.AVERAGE_CADENCE]
+         * Units: rpm
          */
         const val CADENCE_LAP = "TYPE_CADENCE_LAP_ID"
 
         /**
          * Lap Max Cadence - Max. cadence this lap
          * Fields: [Field.MAX_CADENCE]
+         * Units: rpm
          */
         const val MAX_CADENCE_LAP = "TYPE_MAX_CADENCE_LAP_ID"
 
         /**
          * Lap Power - Avg. power output this lap
          * Fields: [Field.AVERAGE_POWER]
+         * Units: W
          */
         const val POWER_LAP = "TYPE_POWER_LAP_ID"
 
         /**
          * Lap Normalized Power® - Normalized Power® this lap
          * Fields: [Field.NORMALIZED_POWER]
+         * Units: W
          */
         const val NORMALIZED_POWER_LAP = "TYPE_NORMALIZED_POWER_LAP_ID"
 
@@ -485,78 +530,91 @@ data class DataType(
         /**
          * Lap Max Power - Max. power output this lap
          * Fields: [Field.MAX_POWER]
+         * Units: W
          */
         const val MAX_POWER_LAP = "TYPE_MAX_POWER_LAP_ID"
 
         /**
          * Lap Torque - Avg. torque this lap in N⋅m
          * Fields: [Field.TORQUE]
+         * Units: N⋅m
          */
         const val TORQUE_LAP = "TYPE_TORQUE_LAP_ID"
 
         /**
          * Lap Max Torque - Max. torque this lap in N⋅m
          * Fields: [Field.TORQUE]
+         * Units: N⋅m
          */
         const val MAX_TORQUE_LAP = "TYPE_MAX_TORQUE_LAP_ID"
 
         /**
          * Lap VAM - Avg. VAM this lap in meters/hour
          * Fields: [Field.VERTICAL_SPEED]
+         * Units: m/h
          */
         const val AVERAGE_VERTICAL_SPEED_LAP = "TYPE_AVERAGE_VERTICAL_SPEED_LAP_ID"
 
         /**
          * Lap Ascent - Total elevation gain this lap
          * Fields: [Field.ELEVATION_GAIN]
+         * Units: m (metric), ft (imperial)
          */
         const val ELEVATION_GAIN_LAP = "TYPE_ELEVATION_GAIN_LAP_ID"
 
         /**
          * Lap Descent - Total elevation descended this lap
          * Fields: [Field.ELEVATION_LOSS]
+         * Units: m (metric), ft (imperial)
          */
         const val ELEVATION_LOSS_LAP = "TYPE_ELEVATION_LOSS_LAP_ID"
 
         /**
          * Lap Min Elevation - Min. altitude this lap
          * Fields: [Field.MIN_ELEVATION]
+         * Units: m (metric), ft (imperial)
          */
         const val MIN_ELEVATION_LAP = "TYPE_MIN_ELEVATION_LAP_ID"
 
         /**
          * Lap Max Elevation - Max. altitude this lap
          * Fields: [Field.MAX_ELEVATION]
+         * Units: m (metric), ft (imperial)
          */
         const val MAX_ELEVATION_LAP = "TYPE_MAX_ELEVATION_LAP_ID"
 
         /**
          * Lap Elevation - Avg. altitude this lap
          * Fields: [Field.AVERAGE_ELEVATION]
+         * Units: m (metric), ft (imperial)
          */
         const val AVERAGE_ELEVATION_LAP = "TYPE_AVERAGE_ELEVATION_LAP_ID"
 
         /**
          * Lap Core Temp - Avg. core body temperature this lap
          * Fields: [Field.CORE_TEMP]
+         * Units: °C (metric), °F (imperial)
          */
         const val AVERAGE_CORE_TEMP_LAP = "TYPE_AVERAGE_CORE_TEMP_LAP_ID"
 
         /**
          * Lap Max Core Temp - Max. core body temperature this lap
          * Fields: [Field.CORE_TEMP]
+         * Units: °C (metric), °F (imperial)
          */
         const val MAX_CORE_TEMP_LAP = "TYPE_MAX_CORE_TEMP_LAP_ID"
 
         /**
          * Lap Skin Temp - Avg. skin temperature this lap
          * Fields: [Field.SKIN_TEMP]
+         * Units: °C (metric), °F (imperial)
          */
         const val AVERAGE_SKIN_TEMP_LAP = "TYPE_AVERAGE_SKIN_TEMP_LAP_ID"
 
         /**
          * Lap Max Skin Temp - Max. skin temperature this lap
          * Fields: [Field.SKIN_TEMP]
+         * Units: °C (metric), °F (imperial)
          */
         const val MAX_SKIN_TEMP_LAP = "TYPE_MAX_SKIN_TEMP_LAP_ID"
 
@@ -585,24 +643,28 @@ data class DataType(
         /**
          * Last Lap Heart Rate - Avg. heart rate of previous lap
          * Fields: [Field.AVG_HR]
+         * Units: bpm
          */
         const val AVERAGE_HR_LAST_LAP = "TYPE_AVERAGE_HR_LAST_LAP_ID"
 
         /**
          * Last Lap Cadence - Avg. cadence of previous lap
          * Fields: [Field.AVERAGE_CADENCE]
+         * Units: rpm
          */
         const val AVERAGE_CADENCE_LAST_LAP = "TYPE_AVERAGE_CADENCE_LAST_LAP_ID"
 
         /**
          * Last Lap Power - Avg. power output in previous lap
          * Fields: [Field.AVERAGE_POWER]
+         * Units: W
          */
         const val AVERAGE_POWER_LAST_LAP = "TYPE_AVERAGE_POWER_LAST_LAP_ID"
 
         /**
          * Last Lap Normalized Power® - Normalized Power® of previous lap
          * Fields: [Field.NORMALIZED_POWER]
+         * Units: W
          */
         const val NORMALIZED_POWER_LAST_LAP = "TYPE_NORMALIZED_POWER_LAST_LAP_ID"
 
@@ -631,86 +693,106 @@ data class DataType(
         /**
          * Current Elevation - Current altitude above or below sea level
          * Fields: [Field.PRESSURE_ELEVATION]
+         * Units: m (metric), ft (imperial)
          */
         const val PRESSURE_ELEVATION_CORRECTION = "TYPE_PRESSURE_ELEVATION_CORRECTION_ID"
 
         /**
          * Ascent - Total elevation gain this ride
          * Fields: [Field.ELEVATION_GAIN]
+         * Units: m (metric), ft (imperial)
          */
         const val ELEVATION_GAIN = "TYPE_ELEVATION_GAIN_ID"
 
         /**
          * Descent - Total elevation descended this ride
          * Fields: [Field.ELEVATION_LOSS]
+         * Units: m (metric), ft (imperial)
          */
         const val ELEVATION_LOSS = "TYPE_ELEVATION_LOSS_ID"
 
         /**
          * Current Grade % - Steepness of current surface
          * Fields: [Field.ELEVATION_GRADE]
+         * Units: m (metric), ft (imperial)
          */
         const val ELEVATION_GRADE = "TYPE_ELEVATION_GRADE_ID"
 
         /**
          * VAM - Current rate of ascent in meters/hour
          * Fields: [Field.VERTICAL_SPEED]
+         * Units: m/h
          */
         const val VERTICAL_SPEED = "TYPE_VERTICAL_SPEED_ID"
 
         /**
          * Average VAM - Avg. VAM this ride in meters/hour
          * Fields: [Field.VERTICAL_SPEED]
+         * Units: m/h
          */
         const val AVERAGE_VERTICAL_SPEED = "TYPE_AVERAGE_VERTICAL_SPEED_ID"
 
         /**
          * 30s Average VAM - 30-second rolling avg. in meters/hour
          * Fields: [Field.VERTICAL_SPEED]
+         * Units: m/h
          */
         const val AVERAGE_VERTICAL_SPEED_30S = "TYPE_AVERAGE_VERTICAL_SPEED_30S_ID"
 
         /**
          * Min Elevation - Lowest altitude this ride
          * Fields: [Field.MIN_ELEVATION]
+         * Units: m (metric), ft (imperial)
          */
         const val MIN_ELEVATION = "TYPE_MIN_ELEVATION_ID"
 
         /**
          * Max Elevation - Highest altitude this ride
          * Fields: [Field.MAX_ELEVATION]
+         * Units: m (metric), ft (imperial)
          */
         const val MAX_ELEVATION = "TYPE_MAX_ELEVATION_ID"
 
         /**
          * Avg Elevation - Mean elevation this ride
          * Fields: [Field.AVERAGE_ELEVATION]
+         * Units: m (metric), ft (imperial)
          */
         const val AVERAGE_ELEVATION = "TYPE_AVERAGE_ELEVATION_ID"
 
         /**
          * Distance to Top - Distance left to top of current climb
          * Fields: [Field.DISTANCE_TO_TOP]
+         * Units: km (metric), mi (imperial)
          */
         const val DISTANCE_TO_TOP = "TYPE_DISTANCE_TO_TOP_ID"
 
         /**
          * Elevation to Top - Elevation left to top of current climb
          * Fields: [Field.ELEVATION_TO_TOP]
+         * Units: m (metric), ft (imperial)
          */
         const val ELEVATION_TO_TOP = "TYPE_ELEVATION_TO_TOP_ID"
 
         /**
          * Distance from Base - Distance since the start of current climb
          * Fields: [Field.DISTANCE_FROM_BOTTOM]
+         * Units: km (metric), mi (imperial)
          */
         const val DISTANCE_FROM_BOTTOM = "TYPE_DISTANCE_FROM_BOTTOM_ID"
 
         /**
          * Elevation from Base - Elevation above the start of current climb
          * Fields: [Field.ELEVATION_FROM_BOTTOM]
+         * Units: m (metric), ft (imperial)
          */
         const val ELEVATION_FROM_BOTTOM = "TYPE_ELEVATION_FROM_BOTTOM_ID"
+
+        /**
+         * Climb Number - Current climb number
+         * Fields: [Field.CLIMB_NUMBER], [Field.TOTAL_CLIMBS]
+         */
+        const val CLIMB_NUMBER = "TYPE_CLIMB_NUMBER_ID"
 
         /**
          * Category: Time
@@ -841,24 +923,28 @@ data class DataType(
         /**
          * Battery - Karoo battery level
          * Fields: [Field.BATTERY_PERCENT]
+         * Units: %
          */
         const val BATTERY_PERCENT = "TYPE_BATTERY_PERCENT_ID"
 
         /**
          * Front Pressure - Tire pressure in front tire
          * Fields: [Field.TIRE_PRESSURE], [Field.TIRE_PRESSURE_TARGET], [Field.TIRE_PRESSURE_RANGE]
+         * Units: kPa (metric), PSI (imperial)
          */
         const val TIRE_PRESSURE_FRONT = "TYPE_TIRE_PRESSURE_FRONT_ID"
 
         /**
          * Rear Pressure - Tire pressure in rear tire
          * Fields: [Field.TIRE_PRESSURE], [Field.TIRE_PRESSURE_TARGET], [Field.TIRE_PRESSURE_RANGE]
+         * Units: kPa (metric), PSI (imperial)
          */
         const val TIRE_PRESSURE_REAR = "TYPE_TIRE_PRESSURE_REAR_ID"
 
         /**
          * Temperature - Current air temperature
          * Fields: [Field.TEMPERATURE]
+         * Units: °C (metric), °F (imperial)
          */
         const val TEMPERATURE = "TYPE_TEMPERATURE_ID"
 
@@ -881,18 +967,21 @@ data class DataType(
         /**
          * Distance to Destination - Distance to end of route
          * Fields: [Field.DISTANCE_TO_DESTINATION], [Field.NAVIGATION_STATE], [Field.REROUTING_ENABLED], [Field.ON_ROUTE]
+         * Units: km (metric), mi (imperial)
          */
         const val DISTANCE_TO_DESTINATION = "TYPE_DISTANCE_TO_DESTINATION_ID"
 
         /**
          * Distance to Next Turn - Distance till next navigation turn
-         * Fields: [Field.DISTANCE_TO_NEXT_TURN]
+         * Fields: [Field.DISTANCE_TO_NEXT_TURN], [Field.NAVIGATION_STATE], [Field.REROUTING_ENABLED], [Field.ON_ROUTE]
+         * Units: km (metric), mi (imperial)
          */
         const val DISTANCE_TO_NEXT_TURN = "TYPE_DISTANCE_TO_NEXT_TURN_ID"
 
         /**
          * Elevation Remaining - Total remaining ascent on current route
          * Fields: [Field.ELEVATION_REMAINING], [Field.NAVIGATION_STATE], [Field.REROUTING_ENABLED], [Field.ON_ROUTE]
+         * Units: m (metric), ft (imperial)
          */
         const val ELEVATION_REMAINING = "TYPE_ELEVATION_REMAINING_ID"
 
@@ -927,11 +1016,12 @@ data class DataType(
         /**
          * Est Range Remaining - Estimated eBike range in current assist mode
          * Fields: [Field.LEV_ESTIMATED_RANGE]
+         * Units: km (metric), mi (imperial)
          */
         const val LEV_ESTIMATED_RANGE = "TYPE_LEV_ESTIMATED_RANGE_ID"
 
         /**
-         * Assist Mode/Level - Current bike assist mode/level
+         * Assist Level - Currently selected bike assist level
          * Fields: [Field.LEV_ASSIST_MODE], [Field.LEV_SUPPORTED_ASSIST_MODES]
          */
         const val LEV_ASSIST_MODE = "TYPE_LEV_ASSIST_MODE_ID"
@@ -939,24 +1029,28 @@ data class DataType(
         /**
          * Burn Rate - Rate of energy consumption, in wh/km or wh/mi
          * Fields: [Field.LEV_ENERGY_CONSUMPTION]
+         * Units: Wh/km (metric), Wh/mi (imperial)
          */
         const val LEV_ENERGY_CONSUMPTION = "TYPE_LEV_ENERGY_CONSUMPTION_ID"
 
         /**
          * 20M Burn Rate - Average rate of energy consumption over the last 20 min
          * Fields: [Field.LEV_20MIN_ENERGY_CONSUMPTION]
+         * Units: Wh/km (metric), Wh/mi (imperial)
          */
         const val LEV_20M_ENERGY_CONSUMPTION = "TYPE_LEV_20M_ENERGY_CONSUMPTION_ID"
 
         /**
          * Bike Motor Power - Current bike motor power output in watts
          * Fields: [Field.LEV_MOTOR_POWER]
+         * Units: W
          */
         const val LEV_MOTOR_POWER = "TYPE_LEV_MOTOR_POWER_ID"
 
         /**
          * Combined Power - Current combined rider and motor power in watts
          * Fields: [Field.LEV_COMBINED_POWER]
+         * Units: W
          */
         const val LEV_COMBINED_POWER = "TYPE_LEV_COMBINED_POWER_ID"
 
@@ -967,36 +1061,42 @@ data class DataType(
         /**
          * Core Body Temp - Current core body temperature
          * Fields: [Field.CORE_TEMP], [Field.CORE_DATA_QUALITY], [Field.CORE_RESERVED]
+         * Units: °C (metric), °F (imperial)
          */
         const val CORE_TEMP = "TYPE_CORE_TEMP_ID"
 
         /**
          * Average Core Body Temp - Avg. core body temperature this ride
          * Fields: [Field.CORE_TEMP]
+         * Units: °C (metric), °F (imperial)
          */
         const val AVERAGE_CORE_TEMP = "TYPE_AVERAGE_CORE_TEMP_ID"
 
         /**
          * Max Core Body Temp - Max. core body temperature this ride
          * Fields: [Field.CORE_TEMP]
+         * Units: °C (metric), °F (imperial)
          */
         const val MAX_CORE_TEMP = "TYPE_MAX_CORE_TEMP_ID"
 
         /**
          * Skin Temp - Current skin temperature
          * Fields: [Field.SKIN_TEMP], [Field.CORE_DATA_QUALITY]
+         * Units: °C (metric), °F (imperial)
          */
         const val SKIN_TEMP = "TYPE_SKIN_TEMP_ID"
 
         /**
          * Average Skin Temp - Avg. skin temperature this ride
          * Fields: [Field.SKIN_TEMP]
+         * Units: °C (metric), °F (imperial)
          */
         const val AVERAGE_SKIN_TEMP = "TYPE_AVERAGE_SKIN_TEMP_ID"
 
         /**
          * Max Skin Temp - Max. skin temperature this ride
          * Fields: [Field.SKIN_TEMP]
+         * Units: °C (metric), °F (imperial)
          */
         const val MAX_SKIN_TEMP = "TYPE_MAX_SKIN_TEMP_ID"
     }
@@ -1121,7 +1221,6 @@ data class DataType(
 
         /**
          * Alternate type: INT_POSITIVE_OR_ZERO
-         * Optional
          */
         const val CLIMB_NUMBER = "FIELD_CLIMB_NUMBER_ID"
 

--- a/lib/src/main/kotlin/io/hammerhead/karooext/models/DataType.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/models/DataType.kt
@@ -87,42 +87,36 @@ data class DataType(
         /**
          * Speed - Current speed
          * Fields: [Field.SPEED]
-         * Units: km/h (metric), mph (imperial)
          */
         const val SPEED = "TYPE_SPEED_ID"
 
         /**
          * Average Speed - Avg. speed this ride
          * Fields: [Field.AVERAGE_SPEED]
-         * Units: km/h (metric), mph (imperial)
          */
         const val AVERAGE_SPEED = "TYPE_AVERAGE_SPEED_ID"
 
         /**
          * Max Speed - Max. speed this ride
          * Fields: [Field.MAX_SPEED]
-         * Units: km/h (metric), mph (imperial)
          */
         const val MAX_SPEED = "TYPE_MAX_SPEED_ID"
 
         /**
          * 3s Average Speed - 3-second rolling avg.
          * Fields: [Field.SMOOTHED_3S_AVERAGE_SPEED]
-         * Units: km/h (metric), mph (imperial)
          */
         const val SMOOTHED_3S_AVERAGE_SPEED = "TYPE_3S_AVERAGE_SPEED_ID"
 
         /**
          * 5s Average Speed - 5-second rolling avg.
          * Fields: [Field.SMOOTHED_5S_AVERAGE_SPEED]
-         * Units: km/h (metric), mph (imperial)
          */
         const val SMOOTHED_5S_AVERAGE_SPEED = "TYPE_5S_AVERAGE_SPEED_ID"
 
         /**
          * 10s Average Speed - 10-second rolling avg.
          * Fields: [Field.SMOOTHED_10S_AVERAGE_SPEED]
-         * Units: km/h (metric), mph (imperial)
          */
         const val SMOOTHED_10S_AVERAGE_SPEED = "TYPE_10S_AVERAGE_SPEED_ID"
 
@@ -133,7 +127,6 @@ data class DataType(
         /**
          * Distance - Distance traveled this ride
          * Fields: [Field.DISTANCE]
-         * Units: km (metric), mi (imperial)
          */
         const val DISTANCE = "TYPE_DISTANCE_ID"
 
@@ -144,7 +137,6 @@ data class DataType(
         /**
          * Heart Rate - Current HR
          * Fields: [Field.HEART_RATE]
-         * Units: bpm
          */
         const val HEART_RATE = "TYPE_HEART_RATE_ID"
 
@@ -157,21 +149,18 @@ data class DataType(
         /**
          * Average Heart Rate - Avg. HR this ride
          * Fields: [Field.AVG_HR]
-         * Units: bpm
          */
         const val AVERAGE_HR = "TYPE_AVERAGE_HR_ID"
 
         /**
          * Max Heart Rate - Max. HR this ride
          * Fields: [Field.MAX_HR]
-         * Units: bpm
          */
         const val MAX_HR = "TYPE_MAX_HR_ID"
 
         /**
          * Percentage of Max HR - Ratio of current HR to your max.
          * Fields: [Field.PERCENT_MAX_HR]
-         * Units: %
          */
         const val PERCENT_MAX_HR = "TYPE_PERCENT_MAX_HR_ID"
 
@@ -184,7 +173,6 @@ data class DataType(
         /**
          * Average % of HRR - Avg. ratio of HR to your HR Reserve this ride
          * Fields: [Field.AVERAGE_PERCENT_HRR]
-         * Units: bpm
          */
         const val AVERAGE_PERCENT_HRR = "TYPE_AVERAGE_PERCENT_HRR_ID"
 
@@ -195,42 +183,36 @@ data class DataType(
         /**
          * Cadence - Current pedaling rate
          * Fields: [Field.CADENCE]
-         * Units: rpm
          */
         const val CADENCE = "TYPE_CADENCE_ID"
 
         /**
          * Average Cadence - Avg. pedaling rate this ride
          * Fields: [Field.AVERAGE_CADENCE]
-         * Units: rpm
          */
         const val AVERAGE_CADENCE = "TYPE_AVERAGE_CADENCE_ID"
 
         /**
          * Max Cadence - Max. pedaling rate this ride
          * Fields: [Field.MAX_CADENCE]
-         * Units: rpm
          */
         const val MAX_CADENCE = "TYPE_MAX_CADENCE_ID"
 
         /**
          * 3s Average Cadence - 3-second rolling avg.
          * Fields: [Field.SMOOTHED_3S_AVERAGE_CADENCE]
-         * Units: rpm
          */
         const val SMOOTHED_3S_AVERAGE_CADENCE = "TYPE_3S_AVERAGE_CADENCE_ID"
 
         /**
          * 5s Average Cadence - 5-second rolling avg.
          * Fields: [Field.SMOOTHED_5S_AVERAGE_CADENCE]
-         * Units: rpm
          */
         const val SMOOTHED_5S_AVERAGE_CADENCE = "TYPE_5S_AVERAGE_CADENCE_ID"
 
         /**
          * 10s Average Cadence - 10-second rolling avg.
          * Fields: [Field.SMOOTHED_10S_AVERAGE_CADENCE]
-         * Units: rpm
          */
         const val SMOOTHED_10S_AVERAGE_CADENCE = "TYPE_10S_AVERAGE_CADENCE_ID"
 
@@ -241,7 +223,6 @@ data class DataType(
         /**
          * Power - Current power output
          * Fields: [Field.POWER]
-         * Units: W
          */
         const val POWER = "TYPE_POWER_ID"
 
@@ -254,56 +235,48 @@ data class DataType(
         /**
          * Average Power - Avg. power output this ride
          * Fields: [Field.AVERAGE_POWER]
-         * Units: W
          */
         const val AVERAGE_POWER = "TYPE_AVERAGE_POWER_ID"
 
         /**
          * Max Power - Max. power output this ride
          * Fields: [Field.MAX_POWER]
-         * Units: W
          */
         const val MAX_POWER = "TYPE_MAX_POWER_ID"
 
         /**
          * 3s Average Power - 3-second rolling avg.
          * Fields: [Field.SMOOTHED_3S_AVERAGE_POWER]
-         * Units: W
          */
         const val SMOOTHED_3S_AVERAGE_POWER = "TYPE_3S_AVERAGE_POWER_ID"
 
         /**
          * 5s Average Power - 5-second rolling avg.
          * Fields: [Field.SMOOTHED_5S_AVERAGE_POWER]
-         * Units: W
          */
         const val SMOOTHED_5S_AVERAGE_POWER = "TYPE_5S_AVERAGE_POWER_ID"
 
         /**
          * 10s Average Power - 10-second rolling avg.
          * Fields: [Field.SMOOTHED_10S_AVERAGE_POWER]
-         * Units: W
          */
         const val SMOOTHED_10S_AVERAGE_POWER = "TYPE_10S_AVERAGE_POWER_ID"
 
         /**
          * 30s Average Power - 30-second rolling avg.
          * Fields: [Field.SMOOTHED_30S_AVERAGE_POWER]
-         * Units: W
          */
         const val SMOOTHED_30S_AVERAGE_POWER = "TYPE_30S_AVERAGE_POWER_ID"
 
         /**
          * Normalized Power® - Normalized Power® this ride
          * Fields: [Field.NORMALIZED_POWER]
-         * Units: W
          */
         const val NORMALIZED_POWER = "TYPE_NORMALIZED_POWER_ID"
 
         /**
          * Percentage of FTP - Current power as a % of functional threshold power
          * Fields: [Field.PERCENT_MAX_FTP]
-         * Units: %
          */
         const val PERCENT_MAX_FTP = "TYPE_PERCENT_MAX_FTP_ID"
 
@@ -322,14 +295,12 @@ data class DataType(
         /**
          * 20min Average Power - 20-min. rolling avg.
          * Fields: [Field.SMOOTHED_20M_AVERAGE_POWER]
-         * Units: W
          */
         const val SMOOTHED_20M_AVERAGE_POWER = "TYPE_20M_AVERAGE_POWER_ID"
 
         /**
          * 1hr Average Power - 1-hr. rolling avg.
          * Fields: [Field.SMOOTHED_1HR_AVERAGE_POWER]
-         * Units: W
          */
         const val SMOOTHED_1HR_AVERAGE_POWER = "TYPE_1HR_AVERAGE_POWER_ID"
 
@@ -384,14 +355,12 @@ data class DataType(
         /**
          * Power to Weight - Power output in watts per kilogram
          * Fields: [Field.POWER_TO_WEIGHT]
-         * Units: W/Kg
          */
         const val POWER_TO_WEIGHT = "TYPE_POWER_TO_WEIGHT"
 
         /**
          * Energy Output - Amount of energy used this ride
          * Fields: [Field.ENERGY_OUTPUT]
-         * Units: kJ
          */
         const val ENERGY_OUTPUT = "TYPE_ENERGY_OUTPUT_ID"
 
@@ -404,7 +373,6 @@ data class DataType(
         /**
          * Calorie Burn Rate - Calories burned per hour this ride
          * Fields: [Field.CALORIES_PER_HOUR]
-         * Units: Cal/h
          */
         const val CALORIES_PER_HOUR = "TYPE_CALORIES_PER_HOUR_ID"
 
@@ -417,28 +385,24 @@ data class DataType(
         /**
          * Torque - Current torque in N⋅m
          * Fields: [Field.TORQUE]
-         * Units: N⋅m
          */
         const val TORQUE = "TYPE_TORQUE_ID"
 
         /**
          * 3s Average Torque - 3-second rolling avg. in N⋅m
          * Fields: [Field.TORQUE]
-         * Units: N⋅m
          */
         const val SMOOTHED_3S_AVERAGE_TORQUE = "TYPE_3S_AVERAGE_TORQUE_ID"
 
         /**
          * Average Torque - Average torque this ride in N⋅m
          * Fields: [Field.TORQUE]
-         * Units: N⋅m
          */
         const val AVERAGE_TORQUE = "TYPE_AVERAGE_TORQUE_ID"
 
         /**
          * Max Torque - Max. torque this ride in N⋅m
          * Fields: [Field.TORQUE]
-         * Units: N⋅m
          */
         const val MAX_TORQUE = "TYPE_MAX_TORQUE_ID"
 
@@ -461,63 +425,54 @@ data class DataType(
         /**
          * Lap Distance - Distance traveled this lap
          * Fields: [Field.DISTANCE]
-         * Units: km (metric), mi (imperial)
          */
         const val DISTANCE_LAP = "TYPE_DISTANCE_LAP_ID"
 
         /**
          * Lap Speed - Avg. speed this lap
          * Fields: [Field.AVERAGE_SPEED]
-         * Units: km/h (metric), mph (imperial)
          */
         const val AVERAGE_SPEED_LAP = "TYPE_AVERAGE_SPEED_LAP_ID"
 
         /**
          * Lap Max Speed - Max. speed this lap
          * Fields: [Field.MAX_SPEED]
-         * Units: km/h (metric), mph (imperial)
          */
         const val MAX_SPEED_LAP = "TYPE_MAX_SPEED_LAP_ID"
 
         /**
          * Lap Heart Rate - Avg. heart rate this lap
          * Fields: [Field.AVG_HR]
-         * Units: bpm
          */
         const val AVERAGE_LAP_HR = "TYPE_AVERAGE_LAP_HR_ID"
 
         /**
          * Lap Max Heart Rate - Max. heart rate this lap
          * Fields: [Field.MAX_HR]
-         * Units: bpm
          */
         const val MAX_HR_LAP = "TYPE_MAX_HR_LAP_ID"
 
         /**
          * Lap Cadence - Avg. cadence this lap
          * Fields: [Field.AVERAGE_CADENCE]
-         * Units: rpm
          */
         const val CADENCE_LAP = "TYPE_CADENCE_LAP_ID"
 
         /**
          * Lap Max Cadence - Max. cadence this lap
          * Fields: [Field.MAX_CADENCE]
-         * Units: rpm
          */
         const val MAX_CADENCE_LAP = "TYPE_MAX_CADENCE_LAP_ID"
 
         /**
          * Lap Power - Avg. power output this lap
          * Fields: [Field.AVERAGE_POWER]
-         * Units: W
          */
         const val POWER_LAP = "TYPE_POWER_LAP_ID"
 
         /**
          * Lap Normalized Power® - Normalized Power® this lap
          * Fields: [Field.NORMALIZED_POWER]
-         * Units: W
          */
         const val NORMALIZED_POWER_LAP = "TYPE_NORMALIZED_POWER_LAP_ID"
 
@@ -530,91 +485,78 @@ data class DataType(
         /**
          * Lap Max Power - Max. power output this lap
          * Fields: [Field.MAX_POWER]
-         * Units: W
          */
         const val MAX_POWER_LAP = "TYPE_MAX_POWER_LAP_ID"
 
         /**
          * Lap Torque - Avg. torque this lap in N⋅m
          * Fields: [Field.TORQUE]
-         * Units: N⋅m
          */
         const val TORQUE_LAP = "TYPE_TORQUE_LAP_ID"
 
         /**
          * Lap Max Torque - Max. torque this lap in N⋅m
          * Fields: [Field.TORQUE]
-         * Units: N⋅m
          */
         const val MAX_TORQUE_LAP = "TYPE_MAX_TORQUE_LAP_ID"
 
         /**
          * Lap VAM - Avg. VAM this lap in meters/hour
          * Fields: [Field.VERTICAL_SPEED]
-         * Units: m/h
          */
         const val AVERAGE_VERTICAL_SPEED_LAP = "TYPE_AVERAGE_VERTICAL_SPEED_LAP_ID"
 
         /**
          * Lap Ascent - Total elevation gain this lap
          * Fields: [Field.ELEVATION_GAIN]
-         * Units: m (metric), ft (imperial)
          */
         const val ELEVATION_GAIN_LAP = "TYPE_ELEVATION_GAIN_LAP_ID"
 
         /**
          * Lap Descent - Total elevation descended this lap
          * Fields: [Field.ELEVATION_LOSS]
-         * Units: m (metric), ft (imperial)
          */
         const val ELEVATION_LOSS_LAP = "TYPE_ELEVATION_LOSS_LAP_ID"
 
         /**
          * Lap Min Elevation - Min. altitude this lap
          * Fields: [Field.MIN_ELEVATION]
-         * Units: m (metric), ft (imperial)
          */
         const val MIN_ELEVATION_LAP = "TYPE_MIN_ELEVATION_LAP_ID"
 
         /**
          * Lap Max Elevation - Max. altitude this lap
          * Fields: [Field.MAX_ELEVATION]
-         * Units: m (metric), ft (imperial)
          */
         const val MAX_ELEVATION_LAP = "TYPE_MAX_ELEVATION_LAP_ID"
 
         /**
          * Lap Elevation - Avg. altitude this lap
          * Fields: [Field.AVERAGE_ELEVATION]
-         * Units: m (metric), ft (imperial)
          */
         const val AVERAGE_ELEVATION_LAP = "TYPE_AVERAGE_ELEVATION_LAP_ID"
 
         /**
          * Lap Core Temp - Avg. core body temperature this lap
          * Fields: [Field.CORE_TEMP]
-         * Units: °C (metric), °F (imperial)
          */
         const val AVERAGE_CORE_TEMP_LAP = "TYPE_AVERAGE_CORE_TEMP_LAP_ID"
 
         /**
          * Lap Max Core Temp - Max. core body temperature this lap
          * Fields: [Field.CORE_TEMP]
-         * Units: °C (metric), °F (imperial)
          */
         const val MAX_CORE_TEMP_LAP = "TYPE_MAX_CORE_TEMP_LAP_ID"
 
         /**
          * Lap Skin Temp - Avg. skin temperature this lap
          * Fields: [Field.SKIN_TEMP]
-         * Units: °C (metric), °F (imperial)
          */
         const val AVERAGE_SKIN_TEMP_LAP = "TYPE_AVERAGE_SKIN_TEMP_LAP_ID"
 
         /**
          * Lap Max Skin Temp - Max. skin temperature this lap
          * Fields: [Field.SKIN_TEMP]
-         * Units: °C (metric), °F (imperial)
          */
         const val MAX_SKIN_TEMP_LAP = "TYPE_MAX_SKIN_TEMP_LAP_ID"
 
@@ -643,28 +585,24 @@ data class DataType(
         /**
          * Last Lap Heart Rate - Avg. heart rate of previous lap
          * Fields: [Field.AVG_HR]
-         * Units: bpm
          */
         const val AVERAGE_HR_LAST_LAP = "TYPE_AVERAGE_HR_LAST_LAP_ID"
 
         /**
          * Last Lap Cadence - Avg. cadence of previous lap
          * Fields: [Field.AVERAGE_CADENCE]
-         * Units: rpm
          */
         const val AVERAGE_CADENCE_LAST_LAP = "TYPE_AVERAGE_CADENCE_LAST_LAP_ID"
 
         /**
          * Last Lap Power - Avg. power output in previous lap
          * Fields: [Field.AVERAGE_POWER]
-         * Units: W
          */
         const val AVERAGE_POWER_LAST_LAP = "TYPE_AVERAGE_POWER_LAST_LAP_ID"
 
         /**
          * Last Lap Normalized Power® - Normalized Power® of previous lap
          * Fields: [Field.NORMALIZED_POWER]
-         * Units: W
          */
         const val NORMALIZED_POWER_LAST_LAP = "TYPE_NORMALIZED_POWER_LAST_LAP_ID"
 
@@ -693,106 +631,86 @@ data class DataType(
         /**
          * Current Elevation - Current altitude above or below sea level
          * Fields: [Field.PRESSURE_ELEVATION]
-         * Units: m (metric), ft (imperial)
          */
         const val PRESSURE_ELEVATION_CORRECTION = "TYPE_PRESSURE_ELEVATION_CORRECTION_ID"
 
         /**
          * Ascent - Total elevation gain this ride
          * Fields: [Field.ELEVATION_GAIN]
-         * Units: m (metric), ft (imperial)
          */
         const val ELEVATION_GAIN = "TYPE_ELEVATION_GAIN_ID"
 
         /**
          * Descent - Total elevation descended this ride
          * Fields: [Field.ELEVATION_LOSS]
-         * Units: m (metric), ft (imperial)
          */
         const val ELEVATION_LOSS = "TYPE_ELEVATION_LOSS_ID"
 
         /**
          * Current Grade % - Steepness of current surface
          * Fields: [Field.ELEVATION_GRADE]
-         * Units: m (metric), ft (imperial)
          */
         const val ELEVATION_GRADE = "TYPE_ELEVATION_GRADE_ID"
 
         /**
          * VAM - Current rate of ascent in meters/hour
          * Fields: [Field.VERTICAL_SPEED]
-         * Units: m/h
          */
         const val VERTICAL_SPEED = "TYPE_VERTICAL_SPEED_ID"
 
         /**
          * Average VAM - Avg. VAM this ride in meters/hour
          * Fields: [Field.VERTICAL_SPEED]
-         * Units: m/h
          */
         const val AVERAGE_VERTICAL_SPEED = "TYPE_AVERAGE_VERTICAL_SPEED_ID"
 
         /**
          * 30s Average VAM - 30-second rolling avg. in meters/hour
          * Fields: [Field.VERTICAL_SPEED]
-         * Units: m/h
          */
         const val AVERAGE_VERTICAL_SPEED_30S = "TYPE_AVERAGE_VERTICAL_SPEED_30S_ID"
 
         /**
          * Min Elevation - Lowest altitude this ride
          * Fields: [Field.MIN_ELEVATION]
-         * Units: m (metric), ft (imperial)
          */
         const val MIN_ELEVATION = "TYPE_MIN_ELEVATION_ID"
 
         /**
          * Max Elevation - Highest altitude this ride
          * Fields: [Field.MAX_ELEVATION]
-         * Units: m (metric), ft (imperial)
          */
         const val MAX_ELEVATION = "TYPE_MAX_ELEVATION_ID"
 
         /**
          * Avg Elevation - Mean elevation this ride
          * Fields: [Field.AVERAGE_ELEVATION]
-         * Units: m (metric), ft (imperial)
          */
         const val AVERAGE_ELEVATION = "TYPE_AVERAGE_ELEVATION_ID"
 
         /**
          * Distance to Top - Distance left to top of current climb
          * Fields: [Field.DISTANCE_TO_TOP]
-         * Units: km (metric), mi (imperial)
          */
         const val DISTANCE_TO_TOP = "TYPE_DISTANCE_TO_TOP_ID"
 
         /**
          * Elevation to Top - Elevation left to top of current climb
          * Fields: [Field.ELEVATION_TO_TOP]
-         * Units: m (metric), ft (imperial)
          */
         const val ELEVATION_TO_TOP = "TYPE_ELEVATION_TO_TOP_ID"
 
         /**
          * Distance from Base - Distance since the start of current climb
          * Fields: [Field.DISTANCE_FROM_BOTTOM]
-         * Units: km (metric), mi (imperial)
          */
         const val DISTANCE_FROM_BOTTOM = "TYPE_DISTANCE_FROM_BOTTOM_ID"
 
         /**
          * Elevation from Base - Elevation above the start of current climb
          * Fields: [Field.ELEVATION_FROM_BOTTOM]
-         * Units: m (metric), ft (imperial)
          */
         const val ELEVATION_FROM_BOTTOM = "TYPE_ELEVATION_FROM_BOTTOM_ID"
-
-        /**
-         * Climb Number - Current climb number
-         * Fields: [Field.CLIMB_NUMBER], [Field.TOTAL_CLIMBS]
-         */
-        const val CLIMB_NUMBER = "TYPE_CLIMB_NUMBER_ID"
 
         /**
          * Category: Time
@@ -923,28 +841,24 @@ data class DataType(
         /**
          * Battery - Karoo battery level
          * Fields: [Field.BATTERY_PERCENT]
-         * Units: %
          */
         const val BATTERY_PERCENT = "TYPE_BATTERY_PERCENT_ID"
 
         /**
          * Front Pressure - Tire pressure in front tire
          * Fields: [Field.TIRE_PRESSURE], [Field.TIRE_PRESSURE_TARGET], [Field.TIRE_PRESSURE_RANGE]
-         * Units: kPa (metric), PSI (imperial)
          */
         const val TIRE_PRESSURE_FRONT = "TYPE_TIRE_PRESSURE_FRONT_ID"
 
         /**
          * Rear Pressure - Tire pressure in rear tire
          * Fields: [Field.TIRE_PRESSURE], [Field.TIRE_PRESSURE_TARGET], [Field.TIRE_PRESSURE_RANGE]
-         * Units: kPa (metric), PSI (imperial)
          */
         const val TIRE_PRESSURE_REAR = "TYPE_TIRE_PRESSURE_REAR_ID"
 
         /**
          * Temperature - Current air temperature
          * Fields: [Field.TEMPERATURE]
-         * Units: °C (metric), °F (imperial)
          */
         const val TEMPERATURE = "TYPE_TEMPERATURE_ID"
 
@@ -967,21 +881,18 @@ data class DataType(
         /**
          * Distance to Destination - Distance to end of route
          * Fields: [Field.DISTANCE_TO_DESTINATION], [Field.NAVIGATION_STATE], [Field.REROUTING_ENABLED], [Field.ON_ROUTE]
-         * Units: km (metric), mi (imperial)
          */
         const val DISTANCE_TO_DESTINATION = "TYPE_DISTANCE_TO_DESTINATION_ID"
 
         /**
          * Distance to Next Turn - Distance till next navigation turn
-         * Fields: [Field.DISTANCE_TO_NEXT_TURN], [Field.NAVIGATION_STATE], [Field.REROUTING_ENABLED], [Field.ON_ROUTE]
-         * Units: km (metric), mi (imperial)
+         * Fields: [Field.DISTANCE_TO_NEXT_TURN]
          */
         const val DISTANCE_TO_NEXT_TURN = "TYPE_DISTANCE_TO_NEXT_TURN_ID"
 
         /**
          * Elevation Remaining - Total remaining ascent on current route
          * Fields: [Field.ELEVATION_REMAINING], [Field.NAVIGATION_STATE], [Field.REROUTING_ENABLED], [Field.ON_ROUTE]
-         * Units: m (metric), ft (imperial)
          */
         const val ELEVATION_REMAINING = "TYPE_ELEVATION_REMAINING_ID"
 
@@ -1016,12 +927,11 @@ data class DataType(
         /**
          * Est Range Remaining - Estimated eBike range in current assist mode
          * Fields: [Field.LEV_ESTIMATED_RANGE]
-         * Units: km (metric), mi (imperial)
          */
         const val LEV_ESTIMATED_RANGE = "TYPE_LEV_ESTIMATED_RANGE_ID"
 
         /**
-         * Assist Level - Currently selected bike assist level
+         * Assist Mode/Level - Current bike assist mode/level
          * Fields: [Field.LEV_ASSIST_MODE], [Field.LEV_SUPPORTED_ASSIST_MODES]
          */
         const val LEV_ASSIST_MODE = "TYPE_LEV_ASSIST_MODE_ID"
@@ -1029,28 +939,24 @@ data class DataType(
         /**
          * Burn Rate - Rate of energy consumption, in wh/km or wh/mi
          * Fields: [Field.LEV_ENERGY_CONSUMPTION]
-         * Units: Wh/km (metric), Wh/mi (imperial)
          */
         const val LEV_ENERGY_CONSUMPTION = "TYPE_LEV_ENERGY_CONSUMPTION_ID"
 
         /**
          * 20M Burn Rate - Average rate of energy consumption over the last 20 min
          * Fields: [Field.LEV_20MIN_ENERGY_CONSUMPTION]
-         * Units: Wh/km (metric), Wh/mi (imperial)
          */
         const val LEV_20M_ENERGY_CONSUMPTION = "TYPE_LEV_20M_ENERGY_CONSUMPTION_ID"
 
         /**
          * Bike Motor Power - Current bike motor power output in watts
          * Fields: [Field.LEV_MOTOR_POWER]
-         * Units: W
          */
         const val LEV_MOTOR_POWER = "TYPE_LEV_MOTOR_POWER_ID"
 
         /**
          * Combined Power - Current combined rider and motor power in watts
          * Fields: [Field.LEV_COMBINED_POWER]
-         * Units: W
          */
         const val LEV_COMBINED_POWER = "TYPE_LEV_COMBINED_POWER_ID"
 
@@ -1061,42 +967,36 @@ data class DataType(
         /**
          * Core Body Temp - Current core body temperature
          * Fields: [Field.CORE_TEMP], [Field.CORE_DATA_QUALITY], [Field.CORE_RESERVED]
-         * Units: °C (metric), °F (imperial)
          */
         const val CORE_TEMP = "TYPE_CORE_TEMP_ID"
 
         /**
          * Average Core Body Temp - Avg. core body temperature this ride
          * Fields: [Field.CORE_TEMP]
-         * Units: °C (metric), °F (imperial)
          */
         const val AVERAGE_CORE_TEMP = "TYPE_AVERAGE_CORE_TEMP_ID"
 
         /**
          * Max Core Body Temp - Max. core body temperature this ride
          * Fields: [Field.CORE_TEMP]
-         * Units: °C (metric), °F (imperial)
          */
         const val MAX_CORE_TEMP = "TYPE_MAX_CORE_TEMP_ID"
 
         /**
          * Skin Temp - Current skin temperature
          * Fields: [Field.SKIN_TEMP], [Field.CORE_DATA_QUALITY]
-         * Units: °C (metric), °F (imperial)
          */
         const val SKIN_TEMP = "TYPE_SKIN_TEMP_ID"
 
         /**
          * Average Skin Temp - Avg. skin temperature this ride
          * Fields: [Field.SKIN_TEMP]
-         * Units: °C (metric), °F (imperial)
          */
         const val AVERAGE_SKIN_TEMP = "TYPE_AVERAGE_SKIN_TEMP_ID"
 
         /**
          * Max Skin Temp - Max. skin temperature this ride
          * Fields: [Field.SKIN_TEMP]
-         * Units: °C (metric), °F (imperial)
          */
         const val MAX_SKIN_TEMP = "TYPE_MAX_SKIN_TEMP_ID"
     }
@@ -1221,6 +1121,7 @@ data class DataType(
 
         /**
          * Alternate type: INT_POSITIVE_OR_ZERO
+         * Optional
          */
         const val CLIMB_NUMBER = "FIELD_CLIMB_NUMBER_ID"
 

--- a/lib/src/main/kotlin/io/hammerhead/karooext/models/DeviceEvent.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/models/DeviceEvent.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 SRAM LLC.
+ * Copyright (c) 2025 SRAM LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,12 @@ data class OnBatteryStatus(val status: BatteryStatus) : DeviceEvent()
 data class OnManufacturerInfo(val info: ManufacturerInfo) : DeviceEvent()
 
 /**
- * Device produced a new data point
+ * Device produced a new data point.
+ *
+ * Typical sensors emit data at 1Hz (once per second) and should continue
+ * to emit even if the value is unchanged. If data is not emitted for some amount
+ * of time, the Karoo system will assume the sensor is idle and treat the view/stream
+ * accordingly.
  *
  * @see [DataPoint]
  */

--- a/lib/src/main/kotlin/io/hammerhead/karooext/models/FitEffect.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/models/FitEffect.kt
@@ -221,7 +221,6 @@ data class WriteToSessionMesg(
 @Serializable
 data class WriteDeveloperDataIdMesg(val developerDataId: Short) : FitEffect
 
-
 /**
  * Internal use by Karoo System when a new [DeveloperField] is used in [FitEffectWithValues]
  *

--- a/lib/src/main/kotlin/io/hammerhead/karooext/models/KarooEvent.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/models/KarooEvent.kt
@@ -477,8 +477,6 @@ data class SavedDevices(
         val name: String,
         /**
          * If the sensor is currently enabled
-         *
-         * @see RideProfile.disabledDevices
          */
         val enabled: Boolean,
         /**

--- a/lib/src/main/kotlin/io/hammerhead/karooext/models/KarooEvent.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/models/KarooEvent.kt
@@ -439,3 +439,102 @@ data class OnMapZoomLevel(
     @Serializable
     data object Params : KarooEventParams()
 }
+
+/**
+ * Observe saved devices
+ *
+ * @since 1.1.5
+ */
+@Serializable
+data class SavedDevices(
+    val devices: List<SavedDevice>,
+) : KarooEvent() {
+    @Serializable
+    data class SavedDevice(
+        val id: String,
+        val connectionType: String,
+        val name: String,
+        val enabled: Boolean,
+        val details: DeviceDetail,
+        val components: Map<String, DeviceDetail>?,
+        val supportedDataTypes: List<String>,
+        val gearInfo: GearInfo?,
+    ) {
+        @Serializable
+        data class DeviceDetail(
+            val lastBattery: BatteryStatus?,
+            val lastBatteryUpdate: Long?,
+            val manufacturer: String?,
+            val serialNumber: String?,
+        )
+
+        @Serializable
+        data class GearInfo(
+            val maxFrontGears: Int,
+            val maxRearGears: Int,
+            val frontTeeth: List<Int>?,
+            val rearTeeth: List<Int>?,
+        )
+    }
+
+    /**
+     * Default params for [Devices] event listener
+     */
+    @Serializable
+    data object Params : KarooEventParams()
+}
+
+/**
+ * Observe bikes
+ *
+ * @since 1.1.5
+ */
+@Serializable
+data class Bikes(
+    val bikes: List<Bike>,
+) : KarooEvent() {
+    @Serializable
+    data class Bike(
+        val id: String,
+        val name: String,
+        val odometer: Double,
+    )
+
+    /**
+     * Default params for [Bikes] event listener
+     */
+    @Serializable
+    data object Params : KarooEventParams()
+}
+
+/**
+ * Observe the active ride profile
+ *
+ * @since 1.1.5
+ */
+@Serializable
+data class ActiveRideProfile(
+    val profile: RideProfile,
+) : KarooEvent() {
+    /**
+     * Default params for [ActiveRideProfile] event listener
+     */
+    @Serializable
+    data object Params : KarooEventParams()
+}
+
+/**
+ * Observe the visible ride page
+ *
+ * @since 1.1.5
+ */
+@Serializable
+data class ActiveRidePage(
+    val page: RideProfile.Page,
+) : KarooEvent() {
+    /**
+     * Default params for [ActiveRidePage] event listener
+     */
+    @Serializable
+    data object Params : KarooEventParams()
+}

--- a/lib/src/main/kotlin/io/hammerhead/karooext/models/KarooEvent.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/models/KarooEvent.kt
@@ -447,41 +447,114 @@ data class OnMapZoomLevel(
  */
 @Serializable
 data class SavedDevices(
+    /**
+     * List of save devices
+     *
+     * @see SavedDevice
+     */
     val devices: List<SavedDevice>,
 ) : KarooEvent() {
+    /**
+     * A device added by the user and saved in the device list
+     */
     @Serializable
     data class SavedDevice(
         /**
+         * ID of the device
+         *
          * @see Device.fromDeviceUid
          */
         val id: String,
+        /**
+         * The connection for this sensor
+         *
+         * One of: ANT_PLUS, BLE, OTHER, EXTENSION
+         */
         val connectionType: String,
+        /**
+         * The name of the sensor
+         */
         val name: String,
+        /**
+         * If the sensor is currently enabled
+         *
+         * @see RideProfile.disabledDevices
+         */
         val enabled: Boolean,
+        /**
+         * Details of the top-level (or only) device
+         */
         val details: DeviceDetail,
+        /**
+         * Associated components and their details
+         *
+         * Null if single device
+         */
         val components: Map<String, DeviceDetail>?,
+        /**
+         * Data types that this sensor provides
+         *
+         * @see DataType.Type
+         */
         val supportedDataTypes: List<String>,
+        /**
+         * Optional configured gearing info
+         *
+         * @see GearInfo
+         */
         val gearInfo: GearInfo?,
     ) {
+        /**
+         * Saved device details
+         */
         @Serializable
         data class DeviceDetail(
+            /**
+             * Battery status at last check
+             *
+             * @see lastBatteryUpdate
+             */
             val lastBattery: BatteryStatus?,
+            /**
+             * Timestamp (ms since epoch) that `lastBattery` was updated
+             */
             val lastBatteryUpdate: Long?,
+            /**
+             * Manufacturer name
+             */
             val manufacturer: String?,
+            /**
+             * Serial number
+             */
             val serialNumber: String?,
         )
 
+        /**
+         * Saved gear info
+         */
         @Serializable
         data class GearInfo(
+            /**
+             * Number of chainrings
+             */
             val maxFrontGears: Int,
+            /**
+             * Number of cogs in the cassette
+             */
             val maxRearGears: Int,
+            /**
+             * User-provided teeth in each chainring (size matches `maxFrontGears`)
+             */
             val frontTeeth: List<Int>?,
+            /**
+             * User-provided teeth in each cog of cassette (size matches `maxRearGears`)
+             */
             val rearTeeth: List<Int>?,
         )
     }
 
     /**
-     * Default params for [Devices] event listener
+     * Default params for [SavedDevices] event listener
      */
     @Serializable
     data object Params : KarooEventParams()
@@ -494,12 +567,29 @@ data class SavedDevices(
  */
 @Serializable
 data class Bikes(
+    /**
+     * List of all bikes
+     *
+     * @see Bike
+     */
     val bikes: List<Bike>,
 ) : KarooEvent() {
+    /**
+     * A saved bike
+     */
     @Serializable
     data class Bike(
+        /**
+         * Unique ID
+         */
         val id: String,
+        /**
+         * Name of the bike
+         */
         val name: String,
+        /**
+         * Distance saved to this bike on Karoo in meters.
+         */
         val odometer: Double,
     )
 
@@ -517,6 +607,9 @@ data class Bikes(
  */
 @Serializable
 data class ActiveRideProfile(
+    /**
+     * The current profile that is active (selected by user on launcher)
+     */
     val profile: RideProfile,
 ) : KarooEvent() {
     /**
@@ -533,6 +626,9 @@ data class ActiveRideProfile(
  */
 @Serializable
 data class ActiveRidePage(
+    /**
+     * The current page with a profile that is visible to the user
+     */
     val page: RideProfile.Page,
 ) : KarooEvent() {
     /**

--- a/lib/src/main/kotlin/io/hammerhead/karooext/models/KarooEvent.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/models/KarooEvent.kt
@@ -451,6 +451,9 @@ data class SavedDevices(
 ) : KarooEvent() {
     @Serializable
     data class SavedDevice(
+        /**
+         * @see Device.fromDeviceUid
+         */
         val id: String,
         val connectionType: String,
         val name: String,

--- a/lib/src/main/kotlin/io/hammerhead/karooext/models/RideProfile.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/models/RideProfile.kt
@@ -65,4 +65,8 @@ data class RideProfile(
         val enabled: Boolean,
         val speedThreshold: Double,
     )
+
+    override fun toString(): String {
+        return "RideProfile($id, name=$name)"
+    }
 }

--- a/lib/src/main/kotlin/io/hammerhead/karooext/models/RideProfile.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/models/RideProfile.kt
@@ -46,25 +46,6 @@ data class RideProfile(
      */
     val indoor: Boolean,
     /**
-     * Configuration of audio alerts
-     *
-     * @see AudioAlerts
-     */
-    val audioAlerts: AudioAlerts,
-    /**
-     * Configuration of auto-pause
-     *
-     * @see AutoPause
-     */
-    val autoPause: AutoPause,
-    /**
-     * List of IDs for sensors which the user has specifically
-     * disabled in this profile.
-     *
-     * @see SavedDevices.SavedDevice.id
-     */
-    val disabledDevices: List<String>,
-    /**
      * Activity type for this profile that is selected at ride review by default.
      *
      * One of: RIDE, EBIKE, MOUNTAIN_BIKE, GRAVEL, EMOUNTAIN_BIKE, VELOMOBILE
@@ -111,58 +92,6 @@ data class RideProfile(
             val gridSize: Pair<Int, Int>,
         )
     }
-
-    /**
-     * Configuration of audio alerts
-     */
-    @Serializable
-    data class AudioAlerts(
-        /**
-         * Top-level enabled preference
-         */
-        val audioAlertsEnabled: Boolean,
-        /**
-         * Enabled preference for sub-category turn-by-turn
-         */
-        val tbtEnabled: Boolean,
-        /**
-         * Enabled preference for sub-category workouts
-         */
-        val workoutsEnabled: Boolean,
-        /**
-         * Enabled preference for sub-category radar
-         */
-        val radarEnabled: Boolean,
-        /**
-         * Enabled preference for sub-category SLS
-         */
-        val slsEnabled: Boolean,
-        /**
-         * Enabled preference for sub-category phone notifications
-         */
-        val phoneNotifications: Boolean,
-        /**
-         * Enabled preference for sub-category LEV (eBike)
-         */
-        val levEnabled: Boolean,
-    )
-
-    /**
-     * Configuration of auto-pause
-     *
-     * @see RideState.Paused.auto
-     */
-    @Serializable
-    data class AutoPause(
-        /**
-         * If auto-pause is used in this profile
-         */
-        val enabled: Boolean,
-        /**
-         * The speed (in m/s) under which the ride will be paused
-         */
-        val speedThreshold: Double,
-    )
 
     /**
      * @suppress

--- a/lib/src/main/kotlin/io/hammerhead/karooext/models/RideProfile.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/models/RideProfile.kt
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2025 SRAM LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.hammerhead.karooext.models
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RideProfile(
+    val id: String,
+    val name: String,
+    val pages: List<Page>,
+    val indoor: Boolean,
+    val audioAlerts: AudioAlerts,
+    val autoPause: AutoPause,
+    val disabledDevices: List<String>,
+    val defaultActivityType: String,
+    val routingPreference: String,
+) {
+    @Serializable
+    data class Page(
+        val mapPage: Boolean,
+        val elements: List<Element>,
+    ) {
+        @Serializable
+        data class Element(
+            /**
+             * @see DataType.Type
+             */
+            val dataTypeId: String,
+            /**
+             * Pair of column span x row span
+             * Total grid size is 60, so Pair(60, 15) would indicate 1/4 height, full width
+             */
+            val gridSize: Pair<Int, Int>,
+        )
+    }
+
+    @Serializable
+    data class AudioAlerts(
+        val audioAlertsEnabled: Boolean,
+        val tbtEnabled: Boolean,
+        val workoutsEnabled: Boolean,
+        val radarEnabled: Boolean,
+        val slsEnabled: Boolean,
+        val phoneNotifications: Boolean,
+        val levEnabled: Boolean,
+    )
+
+    @Serializable
+    data class AutoPause(
+        val enabled: Boolean,
+        val speedThreshold: Double,
+    )
+}

--- a/lib/src/main/kotlin/io/hammerhead/karooext/models/RideProfile.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/models/RideProfile.kt
@@ -18,26 +18,89 @@ package io.hammerhead.karooext.models
 
 import kotlinx.serialization.Serializable
 
+/**
+ * Ride profile with settings and page setup
+ *
+ * Displayed and chosen on launcher in horizontal scroll
+ * and take effect shortly after a profile is scrolled too
+ * even if a ride isn't started.
+ *
+ * @since 1.1.5
+ */
 @Serializable
 data class RideProfile(
+    /**
+     * Unique ID of this profile
+     */
     val id: String,
+    /**
+     * Name given to this profile
+     */
     val name: String,
+    /**
+     * List of each page in the profile
+     */
     val pages: List<Page>,
+    /**
+     * Whether this profile is designated as indoor with no GPS
+     */
     val indoor: Boolean,
+    /**
+     * Configuration of audio alerts
+     *
+     * @see AudioAlerts
+     */
     val audioAlerts: AudioAlerts,
+    /**
+     * Configuration of auto-pause
+     *
+     * @see AutoPause
+     */
     val autoPause: AutoPause,
+    /**
+     * List of IDs for sensors which the user has specifically
+     * disabled in this profile.
+     *
+     * @see SavedDevices.SavedDevice.id
+     */
     val disabledDevices: List<String>,
+    /**
+     * Activity type for this profile that is selected at ride review by default.
+     *
+     * One of: RIDE, EBIKE, MOUNTAIN_BIKE, GRAVEL, EMOUNTAIN_BIKE, VELOMOBILE
+     */
     val defaultActivityType: String,
+    /**
+     * Preference for how routing is configured in this profile.
+     *
+     * One of: ROAD, GRAVEL, MTB
+     */
     val routingPreference: String,
 ) {
+    /**
+     * A page in a profile
+     */
     @Serializable
     data class Page(
+        /**
+         * If this is the map page
+         */
         val mapPage: Boolean,
+        /**
+         * List of elements in this page
+         *
+         * @see Element
+         */
         val elements: List<Element>,
     ) {
+        /**
+         * Element configured in a page
+         */
         @Serializable
         data class Element(
             /**
+             * Data type of this element
+             *
              * @see DataType.Type
              */
             val dataTypeId: String,
@@ -49,23 +112,61 @@ data class RideProfile(
         )
     }
 
+    /**
+     * Configuration of audio alerts
+     */
     @Serializable
     data class AudioAlerts(
+        /**
+         * Top-level enabled preference
+         */
         val audioAlertsEnabled: Boolean,
+        /**
+         * Enabled preference for sub-category turn-by-turn
+         */
         val tbtEnabled: Boolean,
+        /**
+         * Enabled preference for sub-category workouts
+         */
         val workoutsEnabled: Boolean,
+        /**
+         * Enabled preference for sub-category radar
+         */
         val radarEnabled: Boolean,
+        /**
+         * Enabled preference for sub-category SLS
+         */
         val slsEnabled: Boolean,
+        /**
+         * Enabled preference for sub-category phone notifications
+         */
         val phoneNotifications: Boolean,
+        /**
+         * Enabled preference for sub-category LEV (eBike)
+         */
         val levEnabled: Boolean,
     )
 
+    /**
+     * Configuration of auto-pause
+     *
+     * @see RideState.Paused.auto
+     */
     @Serializable
     data class AutoPause(
+        /**
+         * If auto-pause is used in this profile
+         */
         val enabled: Boolean,
+        /**
+         * The speed (in m/s) under which the ride will be paused
+         */
         val speedThreshold: Double,
     )
 
+    /**
+     * @suppress
+     */
     override fun toString(): String {
         return "RideProfile($id, name=$name)"
     }

--- a/lib/src/main/kotlin/io/hammerhead/karooext/models/RideProfile.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/models/RideProfile.kt
@@ -22,7 +22,7 @@ import kotlinx.serialization.Serializable
  * Ride profile with settings and page setup
  *
  * Displayed and chosen on launcher in horizontal scroll
- * and take effect shortly after a profile is scrolled too
+ * and take effect shortly after a profile is scrolled to
  * even if a ride isn't started.
  *
  * @since 1.1.5

--- a/lib/src/main/kotlin/io/hammerhead/karooext/models/ViewEvent.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/models/ViewEvent.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 SRAM LLC.
+ * Copyright (c) 2025 SRAM LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ data class UpdateGraphicConfig(
      * Setting this can be used to overlay graphical elements on existing numeric data field treatment
      * and requires streaming data updates from `startStream`.
      *
-     * If never non-null, defaults to null and streaming data is not rendered.
+     * If never included, defaults to null and streaming data is not rendered.
      */
     val formatDataTypeId: String? = null,
 ) : ViewEvent()
@@ -69,7 +69,8 @@ data class ShowCustomStreamState(
 data class UpdateNumericConfig(
     /**
      * If a single field is present in streaming data point (from startStream),
-     * control how it is formatted and rendered.
+     * control how it is formatted and rendered. Use an ID string from [DataType.Type]
+     * of the matching type which will account for precision and unit conversion.
      *
      * If never applied, defaults to integer precision.
      */


### PR DESCRIPTION
Library:
* Bump version to 1.1.5
* Add events and data classes for bikes, ride profiles, active page, and saved devices

Sample:
* Refactor popup dialog for data tab
* Listen to bikes and show in popup
* Listen to devices and shown in popup
* Listen to active ride profile and show in data
* Listen to active page and show in popup
* Bump versions