### PR TITLE
Add sample BLE device

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 android {
     namespace = "io.hammerhead.sampleext"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "io.hammerhead.sampleext"
@@ -83,6 +83,8 @@ dependencies {
     // coroutines
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.coroutines.rx2)
+
+    implementation("no.nordicsemi.kotlin.ble:client-android:2.0.0-alpha02")
 
     // Hilt
     ksp(libs.hilt.android.compiler)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+
     <application
         android:name="io.hammerhead.sampleext.SampleApplication"
         android:icon="@drawable/ic_sample"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,11 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.BLUETOOTH" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 
     <application
         android:name="io.hammerhead.sampleext.SampleApplication"

--- a/app/src/main/kotlin/io/hammerhead/sampleext/MainActivity.kt
+++ b/app/src/main/kotlin/io/hammerhead/sampleext/MainActivity.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 SRAM LLC.
+ * Copyright (c) 2025 SRAM LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,9 @@
 
 package io.hammerhead.sampleext
 
+import android.Manifest
 import android.annotation.SuppressLint
+import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -26,6 +28,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.core.app.ActivityCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dagger.hilt.android.AndroidEntryPoint
@@ -53,8 +56,16 @@ fun Main(
 @SuppressLint("SetTextI18n")
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    @SuppressLint("InlinedApi")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (ActivityCompat.checkSelfPermission(this, Manifest.permission.BLUETOOTH_SCAN) != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(
+                this,
+                arrayOf(Manifest.permission.BLUETOOTH_SCAN, Manifest.permission.BLUETOOTH_CONNECT),
+                0,
+            )
+        }
         setContent { Main() }
     }
 }

--- a/app/src/main/kotlin/io/hammerhead/sampleext/extension/BleManager.kt
+++ b/app/src/main/kotlin/io/hammerhead/sampleext/extension/BleManager.kt
@@ -1,23 +1,23 @@
 package io.hammerhead.sampleext.extension
 
-import android.annotation.SuppressLint
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onCompletion
-import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.flow.take
 import no.nordicsemi.kotlin.ble.client.android.CentralManager
 import no.nordicsemi.kotlin.ble.client.android.Peripheral
 import no.nordicsemi.kotlin.ble.client.android.native
@@ -26,20 +26,21 @@ import no.nordicsemi.kotlin.ble.core.ConnectionState
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.time.Duration.Companion.seconds
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
 @OptIn(ExperimentalUuidApi::class, ExperimentalCoroutinesApi::class)
-@SuppressLint("StaticFieldLeak")
 @Singleton
 class BleManager @Inject constructor(@ApplicationContext private val context: Context) {
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
-    init {
-    }
-
     private val centralManager by lazy {
         CentralManager.Factory.native(context, scope)
+    }
+
+    private val connectionOptions by lazy {
+        CentralManager.ConnectionOptions.Direct(timeout = 120.seconds, retry = 10, retryDelay = 12.seconds)
     }
 
     fun scan(services: List<Uuid>): Flow<Pair<String, String?>> {
@@ -53,47 +54,52 @@ class BleManager @Inject constructor(@ApplicationContext private val context: Co
             }
             .distinctByPeripheral()
             .map { Pair(it.peripheral.address, it.peripheral.name) }
+            .catch {
+                Timber.w(it, "Error in BLE scan")
+            }
     }
 
     fun connect(address: String): Flow<Peripheral?> {
-        return centralManager.scan {
-            Address(address)
-        }
-            .filter { it.isConnectable }
-            .map { it.peripheral }
-            .take(1)
-            .flatMapLatest { peripheral ->
-                peripheral.state
-                    .onStart {
-                        Timber.i("Connecting to $peripheral")
-                        centralManager.connect(peripheral)
-                        Timber.i("Connected to $peripheral")
+        return flow {
+            val peripheral = centralManager.scan {
+                Address(address)
+            }.filter { it.isConnectable }.map { it.peripheral }.first()
+            try {
+                repeat(10) { i ->
+                    if (i == 0) {
+                        Timber.i("Found $peripheral, connecting...")
+                    } else {
+                        delay(3.seconds)
+                        Timber.i("Reconnecting to $peripheral...")
                     }
-                    .map {
-                        Timber.i("State of $peripheral: $it")
-                        when (it) {
-                            is ConnectionState.Connected -> peripheral
-                            else -> null
-                        }
-                    }
-                    .onCompletion {
-                        Timber.i("Disconnecting from $peripheral")
-                        peripheral.disconnect()
-                        Timber.i("Disconnected from $peripheral")
-                    }
+                    centralManager.connect(peripheral, connectionOptions)
+                    Timber.i("Connected to $peripheral")
+                    emit(peripheral)
+                    // Block while connected
+                    peripheral.state
+                        .filter { it is ConnectionState.Disconnected }
+                        .first()
+                    Timber.i("Device disconnected from $peripheral, state is ${peripheral.state.value}")
+                    emit(null)
+                }
+            } finally {
+                Timber.i("Disconnecting from $peripheral")
+                peripheral.disconnect()
+                Timber.i("Disconnected from $peripheral")
             }
+        }
     }
 
     @OptIn(ExperimentalStdlibApi::class, ExperimentalUuidApi::class)
     fun <T> observeCharacteristic(peripheral: Peripheral, service: Uuid, characteristic: Uuid, parser: (ByteArray) -> T): Flow<T> {
         return peripheral.services(listOf(service))
             .flatMapLatest {
-                Timber.i("Services changed: $it")
+                Timber.d("Services changed: $it")
                 it.firstOrNull()?.characteristics?.firstOrNull { it.uuid == characteristic }?.let { characteristic ->
                     characteristic.subscribe()
                         .map { data ->
                             val value = parser(data)
-                            Timber.i("Data changed: 0x${data.toHexString()} -> $value")
+                            Timber.d("Data changed: 0x${data.toHexString()} -> $value")
                             value
                         }
                         .onCompletion {

--- a/app/src/main/kotlin/io/hammerhead/sampleext/extension/BleManager.kt
+++ b/app/src/main/kotlin/io/hammerhead/sampleext/extension/BleManager.kt
@@ -1,0 +1,141 @@
+package io.hammerhead.sampleext.extension
+
+import android.annotation.SuppressLint
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.flatMapConcat
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.replay
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.suspendCancellableCoroutine
+import no.nordicsemi.kotlin.ble.client.android.CentralManager
+import no.nordicsemi.kotlin.ble.client.android.Peripheral
+import no.nordicsemi.kotlin.ble.client.android.native
+import no.nordicsemi.kotlin.ble.client.distinctByPeripheral
+import no.nordicsemi.kotlin.ble.core.ConnectionState
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+@OptIn(ExperimentalUuidApi::class, ExperimentalCoroutinesApi::class)
+@SuppressLint("StaticFieldLeak")
+@Singleton
+class BleManager @Inject constructor(@ApplicationContext private val context: Context) {
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    init {
+
+    }
+
+    private val centralManager by lazy {
+        CentralManager.Factory.native(context, scope)
+    }
+
+    fun scan(services: List<Uuid>): Flow<Pair<String, String?>> {
+        return centralManager
+            .scan {
+                Any {
+                    services.map {
+                        ServiceUuid(it)
+                    }
+                }
+            }
+            .distinctByPeripheral()
+            .map { Pair(it.peripheral.address, it.peripheral.name) }
+    }
+
+    fun connect(address: String): Flow<Peripheral?> {
+        return centralManager.scan {
+            Address(address)
+        }
+            .filter { it.isConnectable }
+            .map { it.peripheral }
+            .take(1)
+            .flatMapLatest { peripheral ->
+                peripheral.state
+                    .onStart {
+                        Timber.i("Connecting to $peripheral")
+                        centralManager.connect(peripheral)
+                        Timber.i("Connected to $peripheral")
+                    }
+                    .map {
+                        Timber.i("State of $peripheral: $it")
+                        when (it) {
+                            is ConnectionState.Connected -> peripheral
+                            else -> null
+                        }
+                    }
+                    .onCompletion {
+                        Timber.i("Disconnecting from $peripheral")
+                        peripheral.disconnect()
+                        Timber.i("Disconnected from $peripheral")
+                    }
+            }
+    }
+
+    @OptIn(ExperimentalStdlibApi::class, ExperimentalUuidApi::class)
+    fun <T> observeCharacteristic(peripheral: Peripheral, service: Uuid, characteristic: Uuid, parser: (ByteArray) -> T): Flow<T> {
+        return peripheral.services(listOf(service))
+            .flatMapLatest {
+                Timber.i("Services changed: $it")
+                it.firstOrNull()?.characteristics?.firstOrNull { it.uuid == characteristic }?.let { characteristic ->
+                    characteristic.subscribe()
+                        .map { data ->
+                            val value = parser(data)
+                            Timber.i("Data changed: 0x${data.toHexString()} -> $value")
+                            value
+                        }
+                        .onCompletion {
+                            Timber.d("Stopped observing $service:$characteristic")
+                        }
+                } ?: run {
+                    Timber.w("Characteristic $service:$characteristic not found")
+                    emptyFlow()
+                }
+            }
+            .catch {
+                Timber.w("Characteristic $service:$characteristic error: ${it.message}")
+            }
+    }
+
+    suspend fun <T> readCharacteristic(peripheral: Peripheral, service: Uuid, characteristic: Uuid, parser: (ByteArray) -> T): T? {
+        // Wait for service to be discovered then read the characteristic
+        return peripheral.services(listOf(service)).mapNotNull { it.firstOrNull() }.firstOrNull()?.let { service ->
+            service.characteristics.firstOrNull { it.uuid == characteristic }?.let { characteristic ->
+                parser(characteristic.read())
+            }
+        }
+    }
+
+
+    companion object {
+        // UUIDs for the Device Information service (DIS)
+        val DIS_SERVICE_UUID = Uuid.parse("0000180A-0000-1000-8000-00805f9b34fb")
+        val MANUFACTURER_NAME_CHARACTERISTIC_UUID = Uuid.parse("00002A29-0000-1000-8000-00805f9b34fb")
+        val SERIAL_NUMBER_CHARACTERISTIC_UUID = Uuid.parse("00002a25-0000-1000-8000-00805f9b34fb")
+        val MODEL_NUMBER_CHARACTERISTIC_UUID = Uuid.parse("00002a24-0000-1000-8000-00805f9b34fb")
+
+        // UUIDs for the Battery Service (BAS)
+        val BTS_SERVICE_UUID = Uuid.parse("0000180F-0000-1000-8000-00805f9b34fb")
+        val BATTERY_LEVEL_CHARACTERISTIC_UUID = Uuid.parse("00002A19-0000-1000-8000-00805f9b34fb")
+    }
+}

--- a/app/src/main/kotlin/io/hammerhead/sampleext/extension/BleManager.kt
+++ b/app/src/main/kotlin/io/hammerhead/sampleext/extension/BleManager.kt
@@ -7,23 +7,17 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.awaitCancellation
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.flow.replay
 import kotlinx.coroutines.flow.take
-import kotlinx.coroutines.suspendCancellableCoroutine
 import no.nordicsemi.kotlin.ble.client.android.CentralManager
 import no.nordicsemi.kotlin.ble.client.android.Peripheral
 import no.nordicsemi.kotlin.ble.client.android.native
@@ -32,7 +26,6 @@ import no.nordicsemi.kotlin.ble.core.ConnectionState
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -43,7 +36,6 @@ class BleManager @Inject constructor(@ApplicationContext private val context: Co
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     init {
-
     }
 
     private val centralManager by lazy {
@@ -125,7 +117,6 @@ class BleManager @Inject constructor(@ApplicationContext private val context: Co
             }
         }
     }
-
 
     companion object {
         // UUIDs for the Device Information service (DIS)

--- a/app/src/main/kotlin/io/hammerhead/sampleext/extension/BleManager.kt
+++ b/app/src/main/kotlin/io/hammerhead/sampleext/extension/BleManager.kt
@@ -1,3 +1,19 @@
+/**
+ * Copyright (c) 2025 SRAM LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.hammerhead.sampleext.extension
 
 import android.content.Context

--- a/app/src/main/kotlin/io/hammerhead/sampleext/extension/DoubleHrDataType.kt
+++ b/app/src/main/kotlin/io/hammerhead/sampleext/extension/DoubleHrDataType.kt
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2025 SRAM LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.hammerhead.sampleext.extension
+
+import android.content.Context
+import io.hammerhead.karooext.extension.DataTypeImpl
+import io.hammerhead.karooext.internal.ViewEmitter
+import io.hammerhead.karooext.models.DataType
+import io.hammerhead.karooext.models.UpdateNumericConfig
+import io.hammerhead.karooext.models.ViewConfig
+
+/**
+ * Sample data type supporting [DoubleHrSensor] which, while it uses a HR BLE sensor,
+ * is intended as a type specific to this extension rather than a source for the standard heart rate type.
+ */
+class DoubleHrDataType(extension: String) : DataTypeImpl(extension, TYPE_ID) {
+
+    override fun startView(context: Context, config: ViewConfig, emitter: ViewEmitter) {
+        emitter.onNext(UpdateNumericConfig(formatDataTypeId = DataType.Type.HEART_RATE))
+    }
+
+    companion object {
+        const val TYPE_ID = "2hr"
+    }
+}

--- a/app/src/main/kotlin/io/hammerhead/sampleext/extension/DoubleHrSensor.kt
+++ b/app/src/main/kotlin/io/hammerhead/sampleext/extension/DoubleHrSensor.kt
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2025 SRAM LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.hammerhead.sampleext.extension
+
+import android.annotation.SuppressLint
+import io.hammerhead.karooext.internal.Emitter
+import io.hammerhead.karooext.models.BatteryStatus
+import io.hammerhead.karooext.models.ConnectionStatus
+import io.hammerhead.karooext.models.DataPoint
+import io.hammerhead.karooext.models.DataType
+import io.hammerhead.karooext.models.Device
+import io.hammerhead.karooext.models.DeviceEvent
+import io.hammerhead.karooext.models.ManufacturerInfo
+import io.hammerhead.karooext.models.OnBatteryStatus
+import io.hammerhead.karooext.models.OnConnectionStatus
+import io.hammerhead.karooext.models.OnDataPoint
+import io.hammerhead.karooext.models.OnManufacturerInfo
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.launch
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Sample of a real device backed by BLE connection for [DoubleHrDataType] which isn't actually
+ * providing standard [DataType.Source.HEART_RATE] but rather it's own unique type to this extensions.
+ * BLE HR sensor is used for ease of testing the sample because these sensors are more available than
+ * something like glucose or blood pressure.
+ */
+class DoubleHrSensor(
+    private val bleManager: BleManager,
+    extension: String,
+    private val address: String,
+    private val name: String?,
+) : SampleDevice {
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    override val source by lazy {
+        Device(
+            extension,
+            "$PREFIX-$address",
+            listOf(DataType.dataTypeId(extension, DoubleHrDataType.TYPE_ID)),
+            "2hr ${name ?: "??"}",
+        )
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class, ExperimentalUuidApi::class)
+    @SuppressLint("MissingPermission")
+    override fun connect(emitter: Emitter<DeviceEvent>) {
+        val job = scope.launch {
+            bleManager.connect(address)
+                .flatMapLatest { peripheral ->
+                    peripheral?.let {
+                        val connected = flowOf(OnConnectionStatus(ConnectionStatus.CONNECTED))
+                        val hrChanges = bleManager.observeCharacteristic(peripheral, HRS_SERVICE_UUID, HRS_MEASUREMENT_CHARACTERISTIC_UUID) { data ->
+                            val flag = data[0]
+                            if (flag.toInt() and 0x01 != 0) {
+                                // 16-bit HR
+                                ((data[2].toInt() and 0xFF) shl 8) or (data[1].toInt() and 0xFF)
+                            } else {
+                                // 8-bit HR
+                                data[1].toInt() and 0xFF
+                            }
+                        }.map { hr ->
+                            OnDataPoint(
+                                DataPoint(
+                                    source.dataTypes.first(),
+                                    values = mapOf(DataType.Field.SINGLE to hr * 2.0),
+                                    sourceId = source.uid,
+                                ),
+                            )
+                        }
+                        val batteryChanges = bleManager.observeCharacteristic(peripheral, BleManager.BTS_SERVICE_UUID, BleManager.BATTERY_LEVEL_CHARACTERISTIC_UUID) { data ->
+                            if (data.isNotEmpty()) data[0].toInt() and 0xFF else -1
+                        }.map { percent ->
+                            OnBatteryStatus(BatteryStatus.fromPercentage(percent))
+                        }
+                        val manufacturerInfo = flow {
+                            val manufacturer =
+                                bleManager.readCharacteristic(peripheral, BleManager.DIS_SERVICE_UUID, BleManager.MANUFACTURER_NAME_CHARACTERISTIC_UUID) { data ->
+                                    data.decodeToString()
+                                }
+                            val serialNumber = bleManager.readCharacteristic(peripheral, BleManager.DIS_SERVICE_UUID, BleManager.SERIAL_NUMBER_CHARACTERISTIC_UUID) { data ->
+                                data.decodeToString()
+                            }
+                            val modelNumber = bleManager.readCharacteristic(peripheral, BleManager.DIS_SERVICE_UUID, BleManager.MODEL_NUMBER_CHARACTERISTIC_UUID) { data ->
+                                data.decodeToString()
+                            }
+                            emit(OnManufacturerInfo(ManufacturerInfo(manufacturer, serialNumber, modelNumber)))
+                        }
+                        merge(connected, hrChanges, batteryChanges, manufacturerInfo)
+                    } ?: run {
+                        flowOf(OnConnectionStatus(ConnectionStatus.SEARCHING))
+                    }
+                }.collect { event ->
+                    emitter.onNext(event)
+                }
+        }
+        emitter.setCancellable {
+            job.cancel()
+        }
+    }
+
+    @OptIn(ExperimentalUuidApi::class)
+    companion object {
+        const val PREFIX = "2hr"
+
+        // UUIDs for the Heart Rate service
+        val HRS_SERVICE_UUID = Uuid.parse("0000180D-0000-1000-8000-00805f9b34fb")
+        val HRS_MEASUREMENT_CHARACTERISTIC_UUID = Uuid.parse("00002A37-0000-1000-8000-00805f9b34fb")
+    }
+}

--- a/app/src/main/kotlin/io/hammerhead/sampleext/extension/SampleExtension.kt
+++ b/app/src/main/kotlin/io/hammerhead/sampleext/extension/SampleExtension.kt
@@ -16,11 +16,14 @@
 
 package io.hammerhead.sampleext.extension
 
+import android.Manifest
 import android.annotation.SuppressLint
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.PackageManager
+import androidx.core.app.ActivityCompat
 import com.mapbox.geojson.Point
 import com.mapbox.geojson.utils.PolylineUtils
 import com.mapbox.turf.TurfConstants
@@ -259,10 +262,15 @@ class SampleExtension : KarooExtension("sample", "1.0") {
             karooSystem.connect { connected ->
                 if (connected) {
                     karooSystem.dispatch(RequestBluetooth("samp"))
+                    val message = if (ActivityCompat.checkSelfPermission(this@SampleExtension, Manifest.permission.BLUETOOTH_SCAN) == PackageManager.PERMISSION_GRANTED) {
+                        "Sample extension started (permissions granted)"
+                    } else {
+                        "Sample extension started (needs permissions)"
+                    }
                     karooSystem.dispatch(
                         SystemNotification(
                             "sample-started",
-                            "Sample extension started",
+                            message,
                             action = "See it",
                             actionIntent = "io.hammerhead.sampleext.MAIN",
                         ),

--- a/app/src/main/kotlin/io/hammerhead/sampleext/extension/SampleExtension.kt
+++ b/app/src/main/kotlin/io/hammerhead/sampleext/extension/SampleExtension.kt
@@ -41,6 +41,8 @@ import io.hammerhead.karooext.models.MapEffect
 import io.hammerhead.karooext.models.MarkLap
 import io.hammerhead.karooext.models.OnLocationChanged
 import io.hammerhead.karooext.models.OnMapZoomLevel
+import io.hammerhead.karooext.models.ReleaseBluetooth
+import io.hammerhead.karooext.models.RequestBluetooth
 import io.hammerhead.karooext.models.RideState
 import io.hammerhead.karooext.models.ShowPolyline
 import io.hammerhead.karooext.models.ShowSymbols
@@ -62,8 +64,10 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.concurrent.ConcurrentHashMap
@@ -71,11 +75,16 @@ import javax.inject.Inject
 import kotlin.math.absoluteValue
 import kotlin.math.roundToInt
 import kotlin.reflect.full.createInstance
+import kotlin.uuid.ExperimentalUuidApi
 
+@OptIn(ExperimentalUuidApi::class)
 @AndroidEntryPoint
 class SampleExtension : KarooExtension("sample", "1.0") {
     @Inject
     lateinit var karooSystem: KarooSystemService
+
+    @Inject
+    lateinit var bleManager: BleManager
 
     private var serviceJob: Job? = null
     private val devices = ConcurrentHashMap<String, SampleDevice>()
@@ -85,26 +94,34 @@ class SampleExtension : KarooExtension("sample", "1.0") {
             PowerHrDataType(karooSystem, extension),
             CustomSpeedDataType(karooSystem, extension),
             BespokeDataType(extension),
+            DoubleHrDataType(extension),
         )
     }
 
     override fun startScan(emitter: Emitter<Device>) {
         // Find a new sources every 5 seconds
         val job = CoroutineScope(Dispatchers.IO).launch {
-            delay(1000)
-            repeat(Int.MAX_VALUE) {
-                val hr = StaticHrSource(extension, 100 + it * 10)
-                devices.putIfAbsent(hr.source.uid, hr)
-                emitter.onNext(hr.source)
+            val staticSources = flow {
                 delay(1000)
-                val shift = IncrementalShiftingSource(extension, it)
-                devices.putIfAbsent(shift.source.uid, shift)
-                emitter.onNext(shift.source)
-                delay(1000)
-                val bespoke = BespokeDataSource(extension, it)
-                devices.putIfAbsent(bespoke.source.uid, bespoke)
-                emitter.onNext(bespoke.source)
-                delay(1000)
+                repeat(Int.MAX_VALUE) {
+                    val hr = StaticHrSource(extension, 100 + it * 10)
+                    emit(hr)
+                    delay(1000)
+                    val shift = IncrementalShiftingSource(extension, it)
+                    emit(shift)
+                    delay(1000)
+                    val bespoke = BespokeDataSource(extension, it)
+                    emit(bespoke)
+                    delay(1000)
+                }
+            }
+            val bleSources = bleManager.scan(listOf(DoubleHrSensor.HRS_SERVICE_UUID)).map { (address, name) ->
+                Timber.i("BLE Scanned found $address: $name")
+                DoubleHrSensor(bleManager, extension, address, name)
+            }
+            merge(staticSources, bleSources).collect { device ->
+                devices.putIfAbsent(device.source.uid, device)
+                emitter.onNext(device.source)
             }
         }
         emitter.setCancellable {
@@ -113,15 +130,17 @@ class SampleExtension : KarooExtension("sample", "1.0") {
     }
 
     override fun connectDevice(uid: String, emitter: Emitter<DeviceEvent>) {
-        val id = uid.substringAfterLast("-").toIntOrNull() ?: return
-        Timber.d("Connect to $id")
+        Timber.d("Connect to $uid")
         devices.getOrPut(uid) {
-            if (uid.contains(IncrementalShiftingSource.PREFIX)) {
+            val id = uid.substringAfterLast("-").toIntOrNull()
+            if (uid.contains(IncrementalShiftingSource.PREFIX) && id != null) {
                 IncrementalShiftingSource(extension, id)
-            } else if (uid.contains(StaticHrSource.PREFIX)) {
+            } else if (uid.contains(StaticHrSource.PREFIX) && id != null) {
                 StaticHrSource(extension, id)
-            } else if (uid.contains(BespokeDataSource.PREFIX)) {
+            } else if (uid.contains(BespokeDataSource.PREFIX) && id != null) {
                 BespokeDataSource(extension, id)
+            } else if (uid.contains(DoubleHrSensor.PREFIX)) {
+                DoubleHrSensor(bleManager, extension, uid.substringAfterLast("-"), null)
             } else {
                 throw IllegalArgumentException("unknown type for $uid")
             }
@@ -239,6 +258,7 @@ class SampleExtension : KarooExtension("sample", "1.0") {
         serviceJob = CoroutineScope(Dispatchers.IO).launch {
             karooSystem.connect { connected ->
                 if (connected) {
+                    karooSystem.dispatch(RequestBluetooth("samp"))
                     karooSystem.dispatch(
                         SystemNotification(
                             "sample-started",
@@ -319,6 +339,7 @@ class SampleExtension : KarooExtension("sample", "1.0") {
     override fun onDestroy() {
         serviceJob?.cancel()
         serviceJob = null
+        karooSystem.dispatch(ReleaseBluetooth("samp"))
         karooSystem.disconnect()
         super.onDestroy()
     }

--- a/app/src/main/kotlin/io/hammerhead/sampleext/extension/SampleExtension.kt
+++ b/app/src/main/kotlin/io/hammerhead/sampleext/extension/SampleExtension.kt
@@ -261,7 +261,7 @@ class SampleExtension : KarooExtension("sample", "1.0") {
         serviceJob = CoroutineScope(Dispatchers.IO).launch {
             karooSystem.connect { connected ->
                 if (connected) {
-                    karooSystem.dispatch(RequestBluetooth("samp"))
+                    karooSystem.dispatch(RequestBluetooth(extension))
                     val message = if (ActivityCompat.checkSelfPermission(this@SampleExtension, Manifest.permission.BLUETOOTH_SCAN) == PackageManager.PERMISSION_GRANTED) {
                         "Sample extension started (permissions granted)"
                     } else {
@@ -347,7 +347,7 @@ class SampleExtension : KarooExtension("sample", "1.0") {
     override fun onDestroy() {
         serviceJob?.cancel()
         serviceJob = null
-        karooSystem.dispatch(ReleaseBluetooth("samp"))
+        karooSystem.dispatch(ReleaseBluetooth(extension))
         karooSystem.disconnect()
         super.onDestroy()
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,4 +9,6 @@
     <string name="alert_detail">You\'re at %1$s now.</string>
     <string name="bespoke">Bespoke</string>
     <string name="bespoke_description">Bespoke type from sample</string>
+    <string name="double_hr">2HR</string>
+    <string name="double_hr_description">Double HR</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,6 @@
     <string name="alert_detail">You\'re at %1$s now.</string>
     <string name="bespoke">Bespoke</string>
     <string name="bespoke_description">Bespoke type from sample</string>
-    <string name="double_hr">2HR</string>
+    <string name="double_hr">2xHR</string>
     <string name="double_hr_description">Double HR</string>
 </resources>

--- a/app/src/main/res/xml/extension_info.xml
+++ b/app/src/main/res/xml/extension_info.xml
@@ -24,4 +24,10 @@
         graphical="false"
         icon="@drawable/ic_power_hr"
         typeId="power-hr" />
+    <DataType
+        description="@string/double_hr_description"
+        displayName="@string/double_hr"
+        graphical="false"
+        icon="@drawable/ic_sample"
+        typeId="2hr" />
 </ExtensionInfo>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 activity = "1.9.3"
-agp = "8.4.2"
+agp = "8.6.1"
 dokka = "1.9.20"
 kotlin = "2.0.0"
 coreKtx = "1.13.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue May 21 07:24:33 EDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/lib/src/main/kotlin/io/hammerhead/karooext/models/BatteryStatus.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/models/BatteryStatus.kt
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 SRAM LLC.
+ * Copyright (c) 2025 SRAM LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,4 +31,18 @@ enum class BatteryStatus {
     LOW,
     CRITICAL,
     INVALID,
+    ;
+
+    companion object {
+        fun fromPercentage(percentage: Int): BatteryStatus {
+            return when {
+                percentage > 95 -> NEW
+                percentage > 80 -> GOOD
+                percentage > 45 -> OK
+                percentage > 15 -> LOW
+                percentage > 0 -> CRITICAL
+                else -> INVALID
+            }
+        }
+    }
 }


### PR DESCRIPTION
* Add `BleManager` as singleton to manage devices with https://github.com/NordicSemiconductor/Kotlin-BLE-Library
* Add new data type and data source (double HR)
* Find new data source by scanning BLE by service UUID (HRS)
* Connect to data source by scanning until found, then connecting by mac address
* Observe characteristic for HR and emit as double (to be clear it's different from providing HR data)
* Get characteristics for manufacturer info
* Observe characteristic for battery percentage and map to level
* Request bluetooth permission when launching activity
* Show permission state in start notification
* Request bluetooth on extension start and release on end