### PR TITLE
Add elevation, climbs, and POI distances to navigation states

### DIFF
--- a/app/src/main/kotlin/io/hammerhead/sampleext/TabLayout.kt
+++ b/app/src/main/kotlin/io/hammerhead/sampleext/TabLayout.kt
@@ -166,7 +166,6 @@ fun DataTab(mainData: MainData) {
         Text(text = "Karoo System: " + if (mainData.connected) "Connected" else "Disconnected")
         Text(text = "Ride State: ${mainData.rideState}")
         Text(text = "Power: ${(mainData.power as? StreamState.Streaming)?.dataPoint?.singleValue ?: "--"}")
-        Text(text = "Navigation: ${mainData.navigationState}")
         Text(text = "Active profile: ${mainData.rideProfile}")
         ExpandableData(
             buttonText = "Bikes",
@@ -183,6 +182,13 @@ fun DataTab(mainData: MainData) {
             modifier = Modifier.align(Alignment.CenterHorizontally),
         ) {
             Text(mainData.activePage.toString())
+        }
+        ExpandableData(
+            buttonText = "Navigation state",
+            buttonColor = Color.Cyan,
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+        ) {
+            Text(mainData.navigationState.toString())
         }
         ExpandableData(
             buttonText = "Global POIs",

--- a/app/src/main/kotlin/io/hammerhead/sampleext/TabLayout.kt
+++ b/app/src/main/kotlin/io/hammerhead/sampleext/TabLayout.kt
@@ -62,6 +62,13 @@ import io.hammerhead.karooext.models.StreamState
 import io.hammerhead.karooext.models.Symbol
 import io.hammerhead.karooext.models.SystemNotification
 
+enum class Tab {
+    Controls,
+    Data,
+    Nav,
+    Requests,
+}
+
 @Composable
 fun TabLayout(
     mainData: MainData,
@@ -70,8 +77,7 @@ fun TabLayout(
     playBeeps: () -> Unit,
     toggleHomeBackground: () -> Unit,
 ) {
-    var selectedTabIndex by remember { mutableIntStateOf(0) }
-    val tabs = listOf("Controls", "Data", "Nav", "Requests")
+    var selectedTabIndex by remember { mutableIntStateOf(Tab.Controls.ordinal) }
 
     Column(
         modifier = Modifier
@@ -83,25 +89,26 @@ fun TabLayout(
             edgePadding = 2.dp,
             modifier = Modifier.fillMaxWidth(),
         ) {
-            tabs.forEachIndexed { index, title ->
+            Tab.entries.forEachIndexed { index, tab ->
                 Tab(
                     selected = selectedTabIndex == index,
                     onClick = { selectedTabIndex = index },
-                    text = { Text(text = title, fontSize = 12.sp) },
+                    text = { Text(text = tab.name, fontSize = 12.sp) },
                 )
             }
         }
 
-        when (selectedTabIndex) {
-            0 -> ControlsTab(
+        val selectedTab = Tab.entries[selectedTabIndex]
+        when (selectedTab) {
+            Tab.Controls -> ControlsTab(
                 homeBackgroundSet = mainData.homeBackgroundSet,
                 dispatchEffect = dispatchEffect,
                 playBeeps = playBeeps,
                 toggleHomeBackground = toggleHomeBackground,
             )
-            1 -> DataTab(mainData)
-            2 -> NavigationTab(mainData)
-            3 -> RequestsTab(
+            Tab.Data -> DataTab(mainData)
+            Tab.Nav -> NavigationTab(mainData)
+            Tab.Requests -> RequestsTab(
                 httpStatus = mainData.httpStatus,
                 dispatchEffect = dispatchEffect,
                 makeHttpRequest = makeHttpRequest,

--- a/app/src/main/kotlin/io/hammerhead/sampleext/TabLayout.kt
+++ b/app/src/main/kotlin/io/hammerhead/sampleext/TabLayout.kt
@@ -17,6 +17,7 @@
 package io.hammerhead.sampleext
 
 import android.widget.Toast
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -28,8 +29,8 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ScrollableTabRow
 import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
@@ -41,15 +42,18 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.util.fastRoundToInt
+import com.mapbox.geojson.utils.PolylineUtils
 import io.hammerhead.karooext.models.Device
 import io.hammerhead.karooext.models.KarooEffect
 import io.hammerhead.karooext.models.LaunchPinDrop
+import io.hammerhead.karooext.models.OnNavigationState
 import io.hammerhead.karooext.models.PerformHardwareAction
 import io.hammerhead.karooext.models.ReleaseAnt
 import io.hammerhead.karooext.models.RequestAnt
@@ -67,11 +71,16 @@ fun TabLayout(
     toggleHomeBackground: () -> Unit,
 ) {
     var selectedTabIndex by remember { mutableIntStateOf(0) }
-    val tabs = listOf("Controls", "Data", "Requests")
+    val tabs = listOf("Controls", "Data", "Nav", "Requests")
 
-    Column(modifier = Modifier.fillMaxSize()) {
-        TabRow(
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState()),
+    ) {
+        ScrollableTabRow(
             selectedTabIndex = selectedTabIndex,
+            edgePadding = 2.dp,
             modifier = Modifier.fillMaxWidth(),
         ) {
             tabs.forEachIndexed { index, title ->
@@ -91,7 +100,8 @@ fun TabLayout(
                 toggleHomeBackground = toggleHomeBackground,
             )
             1 -> DataTab(mainData)
-            2 -> RequestsTab(
+            2 -> NavigationTab(mainData)
+            3 -> RequestsTab(
                 httpStatus = mainData.httpStatus,
                 dispatchEffect = dispatchEffect,
                 makeHttpRequest = makeHttpRequest,
@@ -184,11 +194,40 @@ fun DataTab(mainData: MainData) {
             Text(mainData.activePage.toString())
         }
         ExpandableData(
-            buttonText = "Navigation state",
-            buttonColor = Color.Cyan,
+            buttonText = "Saved Devices",
+            buttonColor = Color.DarkGray,
             modifier = Modifier.align(Alignment.CenterHorizontally),
         ) {
-            Text(mainData.navigationState.toString())
+            mainData.savedDevices.map {
+                val extDetails = Device.fromDeviceUid(it.id)?.let { "[ext=${it.first} id=${it.second}]" } ?: ""
+                Text("Device: ${it.name} (${it.connectionType}) $extDetails")
+            }
+        }
+    }
+}
+
+@Composable
+fun NavigationTab(mainData: MainData) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+    ) {
+        Text("Navigation state: " + mainData.navigationState.toString())
+        val elevationPolyline = when (mainData.navigationState) {
+            is OnNavigationState.NavigationState.NavigatingRoute -> mainData.navigationState.routeElevationPolyline
+            is OnNavigationState.NavigationState.NavigatingToDestination -> mainData.navigationState.elevationPolyline
+            else -> null
+        }
+        elevationPolyline?.let {
+            ExpandableData(
+                buttonText = "Navigation elevation",
+                buttonColor = Color.Black,
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+            ) {
+                val decoded = PolylineUtils.decode(elevationPolyline, 1)
+                Graph(decoded.map { Pair(it.latitude(), it.longitude()) })
+            }
         }
         ExpandableData(
             buttonText = "Global POIs",
@@ -197,16 +236,6 @@ fun DataTab(mainData: MainData) {
         ) {
             mainData.globalPOIs.map {
                 Text("POI: ${it.name ?: ""} ${it.type}")
-            }
-        }
-        ExpandableData(
-            buttonText = "Saved Devices",
-            buttonColor = Color.DarkGray,
-            modifier = Modifier.align(Alignment.CenterHorizontally),
-        ) {
-            mainData.savedDevices.map {
-                val extDetails = Device.fromDeviceUid(it.id)?.let { "[ext=${it.first} id=${it.second}]" } ?: ""
-                Text("Device: ${it.name} (${it.connectionType}) $extDetails")
             }
         }
     }
@@ -292,6 +321,39 @@ fun RequestsTab(
             Text("System Notification")
         }
         Spacer(modifier = Modifier.height(12.dp))
+    }
+}
+
+@Composable
+fun Graph(data: List<Pair<Double, Double>>) {
+    val maxX = data.maxOfOrNull { it.first } ?: 1.0
+    val maxY = data.maxOfOrNull { it.second } ?: 1.0
+
+    val padding = 16.dp
+
+    Canvas(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(200.dp)
+            .padding(padding),
+    ) {
+        val width = size.width
+        val height = size.height
+
+        val points = data.map {
+            val x = (it.first / maxX * width).toFloat()
+            val y = height - (it.second / maxY * height).toFloat()
+            Offset(x, y)
+        }
+
+        for (i in 0 until points.size - 1) {
+            drawLine(
+                color = Color.Blue,
+                start = points[i],
+                end = points[i + 1],
+                strokeWidth = 4f,
+            )
+        }
     }
 }
 

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 val moduleName = "karoo-ext"
-val libVersion = "1.1.5"
+val libVersion = "1.1.6"
 
 buildscript {
     dependencies {

--- a/lib/src/main/kotlin/io/hammerhead/karooext/internal/Emitter.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/internal/Emitter.kt
@@ -110,6 +110,8 @@ interface Emitter<T> {
 /**
  * Special [Emitter] that includes a function to update [RemoteViews] in addition
  * to [ViewEvent]s.
+ *
+ * [updateView] can only be called at 1Hz, views emitted more frequently will be dropped.
  */
 class ViewEmitter(
     private val packageName: String,

--- a/lib/src/main/kotlin/io/hammerhead/karooext/models/KarooEvent.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/models/KarooEvent.kt
@@ -352,7 +352,7 @@ data class OnNavigationState(
              *
              * @since 1.1.6
              */
-            val routeElevationPolyline: String?,
+            val routeElevationPolyline: String? = null,
             /**
              * Google encoded polyline, precision 5, of the path to navigate back to the route.
              *
@@ -416,7 +416,7 @@ data class OnNavigationState(
              *
              * @since 1.1.6
              */
-            val elevationPolyline: String?,
+            val elevationPolyline: String? = null,
             /**
              * Climbs along the path to destination
              *

--- a/lib/src/main/kotlin/io/hammerhead/karooext/models/KarooEvent.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/models/KarooEvent.kt
@@ -434,6 +434,7 @@ data class OnNavigationState(
 
         /**
          * Data for a climb within a route
+         *
          * @since 1.1.6
          */
         @Serializable

--- a/lib/src/main/kotlin/io/hammerhead/karooext/models/KarooEvent.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/models/KarooEvent.kt
@@ -348,6 +348,12 @@ data class OnNavigationState(
              */
             val routeDistance: Double,
             /**
+             * Pair of distance, elevation, encoded as Google polyline, precision 1, for the selected route.
+             *
+             * @since 1.1.6
+             */
+            val routeElevationPolyline: String?,
+            /**
              * Google encoded polyline, precision 5, of the path to navigate back to the route.
              *
              * Null when on route or off route and using breadcrumb navigation.
@@ -386,7 +392,7 @@ data class OnNavigationState(
              * @suppress
              */
             override fun toString(): String {
-                return "NavigatingRoute($name, routePolyline=[${routePolyline.length}], routeDistance=$routeDistance, rejoinPolyline=[${rejoinPolyline?.length}], rejoinDistance=$rejoinDistance, reversed=$reversed, breadcrumb=$breadcrumb, pois=${pois.map { "POI(${it.name ?: it.type}, dists=${it.distancesAlongRoute.map { it.toInt() }})" }}, climbs=$climbs)"
+                return "NavigatingRoute($name, routePolyline=[${routePolyline.length}], routeDistance=$routeDistance, routeElevation=[${routeElevationPolyline?.length}], rejoinPolyline=[${rejoinPolyline?.length}], rejoinDistance=$rejoinDistance, reversed=$reversed, breadcrumb=$breadcrumb, pois=${pois.map { "POI(${it.name ?: it.type}, dists=${it.distancesAlongRoute.map { it.toInt() }})" }}, climbs=$climbs)"
             }
         }
 
@@ -406,6 +412,12 @@ data class OnNavigationState(
              */
             val polyline: String,
             /**
+             * Pair of distance, elevation, encoded as Google polyline, precision 1, along the suggested path.
+             *
+             * @since 1.1.6
+             */
+            val elevationPolyline: String?,
+            /**
              * Climbs along the path to destination
              *
              * @since 1.1.6
@@ -416,7 +428,7 @@ data class OnNavigationState(
              * @suppress
              */
             override fun toString(): String {
-                return "NavigatingToDestination($destination, polyline=[${polyline.length}], climbs=$climbs)"
+                return "NavigatingToDestination($destination, polyline=[${polyline.length}], elevationPolyline=[${elevationPolyline?.length}], climbs=$climbs)"
             }
         }
 

--- a/lib/src/main/kotlin/io/hammerhead/karooext/models/KarooEvent.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/models/KarooEvent.kt
@@ -375,12 +375,18 @@ data class OnNavigationState(
              * @see [Symbol.POI] [OnGlobalPOIs]
              */
             val pois: List<Symbol.POI>,
+            /**
+             * Climbs along the route
+             *
+             * @since 1.1.6
+             */
+            val climbs: List<Climb> = emptyList(),
         ) : NavigationState() {
             /**
              * @suppress
              */
             override fun toString(): String {
-                return "NavigatingRoute($name, routePolyline=[${routePolyline.length}], routeDistance=$routeDistance, rejoinPolyline=[${rejoinPolyline?.length}], rejoinDistance=$rejoinDistance, reversed=$reversed, breadcrumb=$breadcrumb, pois=${pois.map { "POI(${it.name ?: it.type})" }})"
+                return "NavigatingRoute($name, routePolyline=[${routePolyline.length}], routeDistance=$routeDistance, rejoinPolyline=[${rejoinPolyline?.length}], rejoinDistance=$rejoinDistance, reversed=$reversed, breadcrumb=$breadcrumb, pois=${pois.map { "POI(${it.name ?: it.type}, dists=${it.distancesAlongRoute.map { it.toInt() }})" }}, climbs=$climbs)"
             }
         }
 
@@ -399,14 +405,44 @@ data class OnNavigationState(
              * This will change if the rider deviates from the previous suggested path to the destination.
              */
             val polyline: String,
+            /**
+             * Climbs along the path to destination
+             *
+             * @since 1.1.6
+             */
+            val climbs: List<Climb> = emptyList(),
         ) : NavigationState() {
             /**
              * @suppress
              */
             override fun toString(): String {
-                return "NavigatingToDestination($destination, polyline=[${polyline.length}])"
+                return "NavigatingToDestination($destination, polyline=[${polyline.length}], climbs=$climbs)"
             }
         }
+
+        /**
+         * Data for a climb within a route
+         * @since 1.1.6
+         */
+        @Serializable
+        data class Climb(
+            /**
+             * Distance along the route (m)
+             */
+            val startDistance: Double,
+            /**
+             * Length of the climb (m)
+             */
+            val length: Double,
+            /**
+             * Average grade over the climb (%)
+             */
+            val grade: Double,
+            /**
+             * Total ascent of the climb (m)
+             */
+            val totalElevation: Double,
+        )
     }
 
     /**

--- a/lib/src/main/kotlin/io/hammerhead/karooext/models/Symbol.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/models/Symbol.kt
@@ -59,6 +59,8 @@ sealed interface Symbol {
          * Optional distances that a route POI is found along the route polyline
          *
          * Because POIs are considered along the route by proximity they can appear more than once
+         *
+         * @since 1.1.6
          */
         val distancesAlongRoute: List<Double> = emptyList(),
     ) : Symbol {

--- a/lib/src/main/kotlin/io/hammerhead/karooext/models/Symbol.kt
+++ b/lib/src/main/kotlin/io/hammerhead/karooext/models/Symbol.kt
@@ -55,6 +55,12 @@ sealed interface Symbol {
          * Optional name of the POI
          */
         val name: String? = null,
+        /**
+         * Optional distances that a route POI is found along the route polyline
+         *
+         * Because POIs are considered along the route by proximity they can appear more than once
+         */
+        val distancesAlongRoute: List<Double> = emptyList(),
     ) : Symbol {
         /**
          * Supported string types for POI


### PR DESCRIPTION
**Library**
* Bump to 1.1.6
* Restrict UI (`RemoteView`) updates to once per second and warn
* Add elevation polyline to navigation states (see sample for decoding)
* Add `Climb` with distances into route/navigation polyline
* Add distances along route to POIs that are within the navigation state for route

**Sample App**
* Make tabs scroll for long content
* Separate navigation data to it's own tab (adding elevation graph)
* Make tab bar scroll because there are 4 items